### PR TITLE
Support returning dates for BMI covariate

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -125,7 +125,7 @@ class StudyDefinition:
             [],
         )
 
-    def patients_bmi(
+    def patients_most_recent_bmi(
         self,
         # Set date limits
         on_or_before=None,
@@ -138,9 +138,17 @@ class StudyDefinition:
         include_month=False,
         include_day=False,
     ):
-        """Return BMI as of reference date, ignoring measurements over 10
-        years prior
+        """
+        Return patients' most recent BMI (in the defined period) either
+        computed from weight and height measurements or, where they are not
+        availble, from recorded BMI values. Measurements taken when a patient
+        was below the minimum age are ignored. The height measurement can be
+        taken before (but not after) the defined period as long as the patient
+        was over the minimum age at the time.
 
+        Optionally returns an additional column with the date of the
+        measurement. If the BMI is computed from weight and height then we use
+        the date of the weight measurement for this.
         """
         # From https://github.com/ebmdatalab/tpp-sql-notebook/issues/10:
         #
@@ -462,7 +470,7 @@ class patients:
         return "continuously_registered_between", locals()
 
     @staticmethod
-    def bmi(
+    def most_recent_bmi(
         # Set date limits
         on_or_before=None,
         on_or_after=None,
@@ -476,7 +484,8 @@ class patients:
     ):
         validate_time_period_options(**locals())
 
-        return "bmi", locals()
+        return "most_recent_bmi", locals()
+
     @staticmethod
     def all():
         return "all", locals()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -356,7 +356,7 @@ def test_simple_bmi(include_dates):
         )
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="1995-01-01", on_or_before="2005-01-01", **bmi_kwargs
         ),
     )
@@ -385,7 +385,7 @@ def test_bmi_rounded():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             "2005-01-01",
             include_measurement_date=True,
             include_month=True,
@@ -415,7 +415,7 @@ def test_bmi_with_zero_values():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="1995-01-01",
             on_or_before="2005-01-01",
             include_measurement_date=True,
@@ -446,7 +446,7 @@ def test_explicit_bmi_fallback():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="1995-01-01",
             on_or_before="2005-01-01",
             include_measurement_date=True,
@@ -473,7 +473,7 @@ def test_no_bmi_when_old_date():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="1995-01-01",
             on_or_before="2005-01-01",
             include_measurement_date=True,
@@ -500,7 +500,7 @@ def test_no_bmi_when_measurements_of_child():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="1995-01-01",
             on_or_before="2005-01-01",
             include_measurement_date=True,
@@ -527,7 +527,7 @@ def test_no_bmi_when_measurement_after_reference_date():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="1990-01-01",
             on_or_before="2000-01-01",
             include_measurement_date=True,
@@ -562,7 +562,7 @@ def test_bmi_when_only_some_measurements_of_child():
 
     study = StudyDefinition(
         population=patients.all(),
-        BMI=patients.bmi(
+        BMI=patients.most_recent_bmi(
             on_or_after="2005-01-01",
             on_or_before="2015-01-01",
             include_measurement_date=True,


### PR DESCRIPTION
The signature of the BMI function now looks like this:
```py
def patients_most_recent_bmi(
    self,
    # Set date limits
    on_or_before=None,
    on_or_after=None,
    between=None,
    minimum_age_at_measurement=16,
    # Add an additional column indicating when measurement was taken
    include_measurement_date=False,
    # If we're returning a date, how granular should it be?
    include_month=False,
    include_day=False,
):
    """
    Return patients' most recent BMI (in the defined period) either
    computed from weight and height measurements or, where they are not
    availble, from recorded BMI values. Measurements taken when a patient
    was below the minimum age are ignored. The height measurement can be
    taken before (but not after) the defined period as long as the patient
    was over the minimum age at the time.

    Optionally returns an additional column with the date of the
    measurement. If the BMI is computed from weight and height then we use
    the date of the weight measurement for this.
    """
```