### PR TITLE
Fix newline handling in expression parser

### DIFF
--- a/datalab_cohorts/expressions.py
+++ b/datalab_cohorts/expressions.py
@@ -72,21 +72,19 @@ def is_allowed(token):
     """
     ttype = token.ttype
     value = token.value
-    # Deliberately `in` rather than `is` as there are multiple comment types
-    # and the TokenType class overrides `__contains__`
     if ttype in ttypes.Comment:
         return IGNORE
-    if ttype is ttypes.Whitespace:
+    if ttype in ttypes.Whitespace:
         return IGNORE
-    if ttype is ttypes.Name:
+    if ttype in ttypes.Name:
         return True
-    if ttype is ttypes.Punctuation:
+    if ttype in ttypes.Punctuation:
         return value in ["(", ")"]
-    if ttype is ttypes.Keyword:
+    if ttype in ttypes.Keyword:
         return value in ["AND", "OR", "NOT"]
-    if ttype is ttypes.Comparison:
+    if ttype in ttypes.Comparison:
         return value in [">", "<", ">=", "<=", "=", "!="]
-    if ttype is ttypes.Number.Float or ttype is ttypes.Number.Integer:
+    if ttype in ttypes.Number.Float or ttype in ttypes.Number.Integer:
         return True
     return False
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -813,7 +813,11 @@ def test_patients_satisfying_with_hidden_columns():
         sex=patients.sex(),
         age=patients.age_as_of("2020-01-01"),
         at_risk=patients.satisfying(
-            "(age > 70 AND sex = M) OR has_asthma",
+            """
+            (age > 70 AND sex = M)
+            OR
+            has_asthma
+            """,
             has_asthma=patients.with_these_clinical_events(
                 codelist([condition_code], "ctv3")
             ),


### PR DESCRIPTION
The general fix here is to use `in` rather than `is` when checking token
types as this matches on any subtypes. For example, newline tokens are
a subtype of the more general whitespace type.