### PR TITLE
Fix collation mismatch issues

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -134,7 +134,10 @@ class StudyDefinition:
             (
                 f"""
                 CREATE TABLE {table_name} (
-                  code VARCHAR({max_code_len}), category VARCHAR(MAX)
+                  -- Because some code systems are case-sensitive we need to
+                  -- use a case-sensitive collation here
+                  code VARCHAR({max_code_len}) COLLATE Latin1_General_BIN,
+                  category VARCHAR(MAX)
                 )
                 """,
                 f"INSERT INTO {table_name} (code, category) VALUES(?, ?)",

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -76,7 +76,7 @@ class MedicationDictionary(Base):
     Form = Column(String)
     Strength = Column(String)
     CompanyName = Column(String)
-    DMD_ID = Column(String)
+    DMD_ID = Column(String(collation="Latin1_General_BIN"))
 
 
 class CodedEvent(Base):
@@ -87,7 +87,7 @@ class CodedEvent(Base):
         "Patient", back_populates="CodedEvents", cascade="all, delete"
     )
     CodedEvent_ID = Column(Integer, primary_key=True)
-    CTV3Code = Column(String)
+    CTV3Code = Column(String(collation="Latin1_General_BIN"))
     NumericValue = Column(Float)
     ConsultationDate = Column(DateTime)
     SnomedConceptId = Column(String)


### PR DESCRIPTION
When we tried to run against the dummy data it would fail with the
error:
```
Cannot resolve the collation conflict between
"SQL_Latin1_General_CP1_CI_AS" and "Latin1_General_BIN" in the equal to
operation. (468) (SQLExecDirectW)
```

This is because Read 3 codes are case-senstive and so the CTV3Code
column has a case-senstive collation.