### PR TITLE
Allow specifying `include_day` without `include_month`

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -1263,8 +1263,8 @@ def truncate_date(column, include_month, include_day):
     date_length = 4
     if include_month:
         date_length = 7
-        if include_day:
-            date_length = 10
+    if include_day:
+        date_length = 10
     # Style 23 below means YYYY-MM-DD format, see:
     # https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15#date-and-time-styles
     return f"CONVERT(VARCHAR({date_length}), {column}, 23)"


### PR DESCRIPTION
I've noticed that one of our new cohort definitions already does this
and rather than change that it seems better to fix the confusing API so that if you
write `include_day = True` it automatically assumes `include_month = True`.

Longer term, I think these flags should in any case be replaced by something
like:

  dates_as="year_only" | "year_and_month_only" | "year_month_and_day"

Or maybe this:

  dates_as="YYYY" | "YYYY-MM" | "YYYY-MM-DD"

For a Python API I dislike passing string options around like this but
for our purposes (emphasising readability over writablility) I think
it's actually better.