### PR TITLE
Make latest windows build obvious

### DIFF
--- a/.github/workflows/build_runner.yaml
+++ b/.github/workflows/build_runner.yaml
@@ -4,6 +4,7 @@ on:
     paths:
     - "run.py"
     - "datalab_cohorts/**"
+    - "build_runner.yaml"
 
 jobs:
   build:
@@ -28,23 +29,25 @@ jobs:
     - name: Build with pyinstaller
       run: |
         pyinstaller run.py --onefile --hidden-import=datalab_cohorts
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create Prelease (non-master branch) Release
+      if: github.ref != 'master'
+      uses: "marvinpinto/action-automatic-releases@latest"
       with:
-        tag_name: ${{ github.run_id }}
-        release_name: Release ${{ github.run_id }}
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: branch-${{ github.ref }}
+        draft: false
+        prerelease: true
+        files: |
+          ./dist/run.exe
+
+    - name: Create full (master branch) Release
+      if: github.ref == 'master'
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: "latest"
         draft: false
         prerelease: false
-    - name: Upload Windows binary
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above
-        asset_path: ./dist/run.exe
-        asset_name: run.exe
-        asset_content_type: application/vnd.microsoft.portable-executable
+        files: |
+          ./dist/run.exe

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ for inspiration.
 You'll want to install a couple of things:
 
 * [This ODBC driver from Microsoft]( https://www.microsoft.com/en-us/download/details.aspx?id=56567)
-* The latest `run.exe` from [here](https://github.com/ebmdatalab/opencorona-research-template/releases)
-  * This must be copied to the root folder of your research repository
+* The latest `run.exe` from [here](../../releases/latest)
+  * This must be copied to and run from the root folder of your research repository
+  * Note that if you're testing a new branch with new `runner` functionality, you'll need to download the latest `run.exe` that is *tagged with that branch name* from the **Releases** section of github
 
 You need to obtain the "database URL", which includes a username and
 password.  When running outside the secure environment, obtain a URL


### PR DESCRIPTION
This PR introduces a release for each branch, called `branch-` + `<ref-of-branch>`; it will be marked as a "prerelease", which makes it appear as such in the Github UI.

The master branch will always be released with the `latest` tag, as a full release, making it possible to provide users with a consistent URL to the latest `run.exe` artefact.