### PR TITLE
Support multi-level column definitions

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -984,6 +984,11 @@ class StudyDefinition:
         else:
             default_value = ""
         clauses = []
+        # Remove any as-yet undefined columns; referencing these should trigger
+        # an error immediately, rather that producing bad SQL later
+        column_definitions = {
+            k: v for (k, v) in column_definitions.items() if v is not None
+        }
         for category, expression in category_definitions.items():
             # The column references in the supplied expression need to be
             # rewritten to ensure they refer to the correct CTE. The formatting

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1388,3 +1388,12 @@ def test_column_name_clashes_produce_errors():
                 age=patients.age_as_of("2010-01-01"),
             ),
         )
+
+
+def test_recursive_definitions_produce_errors():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            this=patients.satisfying("that = 1"),
+            that=patients.satisfying("this = 1"),
+        )


### PR DESCRIPTION
This allows us to have calculated columns (i.e. columns defined with an expression using `satisfying` or `categorised_as`) whose values depend on other calculated columns. The only restriction is that expressions can only reference columns which appear before them in the study definition.

This will be required for some upcoming covariates (e.g. new asthma definition which depends on smoking status).

This implementation also supports arbitrarily nesting the definitions and adds a check for uniqueness of column names. (In future we might be able to rewrite these names to avoid this check, but for now this makes sure we don't accidentally do something stupid.)