### PR TITLE
Support query we need to count COPD exacerbations

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1640,7 +1640,7 @@ def test_quote():
     assert quote("foo") == "'foo'"
 
 
-def test_number_of_episodes_in_period():
+def test_number_of_episodes():
     session = make_session()
     session.add_all(
         [
@@ -1691,10 +1691,10 @@ def test_number_of_episodes_in_period():
         population=patients.all(),
         episode_count=patients.with_these_clinical_events(
             foo_codes,
-            ignore_events_where_these_codes_occur_on_same_day=bar_codes,
             on_or_before="2020-01-01",
-            returning="number_of_episodes_in_period",
-            only_count_events_as_new_episode_when=">14 days after end of previous episode",
+            ignore_days_where_these_codes_occur=bar_codes,
+            returning="number_of_episodes",
+            episode_defined_as="series of events each <= 14 days apart",
         ),
     )
     results = study.to_dicts()


### PR DESCRIPTION
This adds some extra options to the `with_these_clinical_events`
function:
```py
study = StudyDefinition(
    population=patients.all(),
    episode_count=patients.with_these_clinical_events(
        lrti_and_aecopd_codes,
        on_or_before="2020-01-01",
        ignore_days_where_these_codes_occur=annual_review_codes,
        returning="number_of_episodes",
        episode_defined_as="series of events each <= 14 days apart",
    ),
)
```

This gives the impression of being a slightly more general API than it
actually is. In particular, the definition for the washout period only
accepts exactly one format of string with the number of days allowed to
vary. The guiding principle I've followed is to keep the API explict and
as self-documenting as possible.

The SQL implementation itself uses the `LAG` function which, I believe,
gives us a fairly efficient way of getting "time since previous event".
Where this is less or equal to the washout period we set the
"is_new_episode" flag to 0, otherwise we set it to 1. Summing over these
flags gives us the episode count.

The "ignore on same day" clause is implemented using a correlated
subquery which may or may not have good enough performance in the real
data.