### PR TITLE
Fix pandas-based descriptives generation

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -224,8 +224,13 @@ class StudyDefinition:
             else:
                 generated_df = generate(population, **kwargs)
             try:
+                if dtype == "Int64":
+                    # When defining expectations, the more
+                    # user-friendly `int` is used
+                    dtype = "int"
                 df[colname] = generated_df[dtype]
             except KeyError:
+
                 raise ValueError(
                     f"Column definition {colname} does not return expected type {dtype}"
                 )
@@ -260,7 +265,12 @@ class StudyDefinition:
             unique_check.assert_unique_ids()
 
     def csv_to_df(self, csv_name):
-        return pd.read_csv(csv_name, **self.pandas_csv_args)
+        return pd.read_csv(
+            csv_name,
+            dtype=self.pandas_csv_args["dtype"],
+            converters=self.pandas_csv_args["converters"],
+            parse_dates=self.pandas_csv_args["parse_dates"],
+        )
 
     def get_pandas_csv_args(self, covariate_definitions):
         def tobool(val):
@@ -309,9 +319,9 @@ class StudyDefinition:
             elif returning == "numeric_value":
                 dtypes[name] = "float"
             elif returning == "number_of_matches_in_period":
-                dtypes[name] = "int"
+                dtypes[name] = "Int64"
             elif returning == "number_of_episodes":
-                dtypes[name] = "int"
+                dtypes[name] = "Int64"
             elif returning == "binary_flag":
                 converters[name] = tobool
                 dtypes[name] = "bool"
@@ -320,7 +330,7 @@ class StudyDefinition:
             elif returning:
                 dtypes[name] = "category"
             elif funcname == "age_as_of":
-                dtypes[name] = "int"
+                dtypes[name] = "Int64"
             elif funcname == "sex":
                 dtypes[name] = "category"
             elif funcname == "have_died_of_covid":

--- a/run.py
+++ b/run.py
@@ -231,6 +231,7 @@ def make_chart(name, series, dtype):
         plt.xticks(rotation=45, ha="right")
     elif is_numeric_dtype(dtype):
         # Trim percentiles and negatives which are usually bad data
+        series = series.fillna(0)
         series = series[
             (series < np.percentile(series, 95))
             & (series > np.percentile(series, 5))

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -38,7 +38,7 @@ def test_age_dtype_generation():
     )
     result = _converters_to_names(study.pandas_csv_args)
     assert result == {
-        "dtype": {"age": "int"},
+        "dtype": {"age": "Int64"},
         "parse_dates": [],
         "date_col_for": {},
         "converters": {},


### PR DESCRIPTION
Ported from ICS repo

* We require nullable ints (Int64) due to the way expectations
generate expected incidence
* Bad call signature for read_csv