### PR TITLE
Automatically set category ratios for `satisfying`

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -1538,8 +1538,11 @@ class patients:
         return "categorised_as", process_arguments(locals())
 
     @staticmethod
-    def satisfying(expression, **extra_columns):
+    def satisfying(expression, return_expectations=None, **extra_columns):
         category_definitions = {1: expression, 0: "DEFAULT"}
+        if return_expectations is None:
+            return_expectations = {}
+        return_expectations["category"] = {"ratios": {1: 1, 0: 0}}
         # Remove from local namespace
         del expression
         return "categorised_as", process_arguments(locals())

--- a/datalab_cohorts/expectation_generators.py
+++ b/datalab_cohorts/expectation_generators.py
@@ -58,7 +58,9 @@ def generate_dates(population, earliest_date, latest_date, rate):
         distribution = uniform.rvs(size=int(population)) * elapsed_days
         distribution = distribution.astype("int")
     else:
-        raise ValueError("Only exponential_increase and uniform distributions currently supported")
+        raise ValueError(
+            "Only exponential_increase and uniform distributions currently supported"
+        )
 
     # And then sample it back down to the requested population size
     distribution = np.random.choice(distribution, population, replace=False)

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -229,6 +229,7 @@ def test_data_generator_date_exponential_increase():
         assert count < max_count
         max_count = count
 
+
 def test_data_generator_date_uniform():
     population_size = 100000
     incidence = 0.5
@@ -249,6 +250,7 @@ def test_data_generator_date_uniform():
     expected = (population_size * incidence) / 10
     for count in date_counts:
         assert isclose(count, expected, rel_tol=0.1)
+
 
 def test_data_generator_category_and_date():
     population_size = 10000
@@ -572,6 +574,28 @@ def test_make_df_from_expectations_with_number_of_episodes():
     population_size = 10000
     result = study.make_df_from_expectations(population_size)
     assert result.columns == ["episode_count"]
+
+
+def test_make_df_from_expectations_with_satisfying():
+    study = StudyDefinition(
+        population=patients.all(),
+        has_condition=patients.satisfying(
+            "condition_a OR condition_b",
+            condition_a=patients.with_these_clinical_events(
+                codelist(["A", "B", "C"], system="ctv3")
+            ),
+            condition_b=patients.with_these_clinical_events(
+                codelist(["X", "Y", "Z"], system="ctv3")
+            ),
+            return_expectations={
+                "date": {"earliest": "2001-01-01", "latest": "2020-03-01"},
+                "incidence": 0.95,
+            },
+        ),
+    )
+    population_size = 10000
+    result = study.make_df_from_expectations(population_size)
+    assert result.columns == ["has_condition"]
 
 
 def test_make_df_from_expectations_doesnt_alter_defaults():


### PR DESCRIPTION
The `satisfying` method is just syntatic sugar over `categorised_as`
with `1` and `0` as the two categories. We need to handle this fact in
the `return_expectations` argument as well.

(Note, this doesn't quite match the "what we want" example in the linked
issue because `earliest` is a required argument to `date` as well as
`latest`. I assume this was an accidental omission.)

Closes #106