### PR TITLE
Add function to combine codelists

### DIFF
--- a/datalab_cohorts/__init__.py
+++ b/datalab_cohorts/__init__.py
@@ -2077,10 +2077,17 @@ def combine_codelists(first_codelist, *other_codelists):
             )
         if first_codelist.has_categories != other.has_categories:
             raise ValueError("Cannot combine categorised and uncategorised codelists")
-    combined = codelist(first_codelist, first_codelist.system)
-    for other in other_codelists:
-        combined.extend(other)
-    return combined
+    combined_dict = {}
+    for lst in (first_codelist,) + other_codelists:
+        for item in lst:
+            code = item[0] if lst.has_categories else item
+            if code in combined_dict and item != combined_dict[code]:
+                raise ValueError(
+                    f"Inconsistent categorisation: {item} and {combined_dict[code]}"
+                )
+            else:
+                combined_dict[code] = item
+    return codelist(combined_dict.values(), first_codelist.system)
 
 
 class UniqueCheck:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1675,3 +1675,18 @@ def test_combine_codelists_raises_error_for_mixed_categorisation():
     list_2 = codelist(["X", "Y", "Z"], system="icd10")
     with pytest.raises(ValueError):
         combine_codelists(list_1, list_2)
+
+
+def test_combine_codelists_with_duplicates():
+    list_1 = codelist(["A", "B", "C"], system="ctv3")
+    list_2 = codelist(["X", "B", "Z"], system="ctv3")
+    combined = combine_codelists(list_1, list_2)
+    expected = codelist(["A", "B", "C", "X", "Z"], system="ctv3")
+    assert combined == expected
+
+
+def test_combine_codelists_raises_error_on_inconsistent_categorisation():
+    list_1 = codelist([("A", "foo"), ("B", "bar")], system="icd10")
+    list_2 = codelist([("X", "foo"), ("B", "foo")], system="icd10")
+    with pytest.raises(ValueError):
+        combine_codelists(list_1, list_2)


### PR DESCRIPTION
Usage looks like this:
```py
from datalab_cohorts import combine_codelists

combined = combine_codelists(codelist_1, codelist_2, codelist_3, ...)
```

Duplicate codes are removed. An error will be raised if codelists aren't from the same code system,
or if some codelists are categorised and others aren't, or if two codelists assign the same code to different categories.

Closes #112