### PR TITLE
Support "episode counting" logic for medications

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1505,6 +1505,100 @@ def test_number_of_episodes():
     assert [i["episode_count"] for i in results] == ["3", "0"]
 
 
+def test_number_of_episodes_for_medications():
+    oral_steriod = MedicationDictionary(
+        FullName="Oral Steroid", DMD_ID="ab12", MultilexDrug_ID="1"
+    )
+    other_drug = MedicationDictionary(
+        FullName="Other Drug", DMD_ID="cd34", MultilexDrug_ID="2"
+    )
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                MedicationIssues=[
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-01"
+                    ),
+                    # Throw in some irrelevant prescriptions
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-02"
+                    ),
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                    ),
+                    # These two should be merged in to the previous event
+                    # because there's not more than 14 days between them
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-14"
+                    ),
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-20"
+                    ),
+                    # This is just outside the limit so should count as another event
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-02-04"
+                    ),
+                    # This shouldn't count because there's an "ignore" event on
+                    # the same day (though at a different time)
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod,
+                        ConsultationDate="2012-01-01T10:45:00",
+                    ),
+                    # This should be another episode
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2015-03-05"
+                    ),
+                    # This is after the time limit and so shouldn't count
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2020-02-05"
+                    ),
+                ],
+                CodedEvents=[
+                    # This "ignore" event should cause us to skip one of the
+                    # meds issues above
+                    CodedEvent(CTV3Code="bar2", ConsultationDate="2012-01-01T16:10:00"),
+                    # This "ignore" event should have no effect because it
+                    # doesn't occur on the same day as any meds issue
+                    CodedEvent(CTV3Code="bar1", ConsultationDate="2015-03-06"),
+                ],
+            ),
+            # This patient doesn't have any relevant events or prescriptions
+            Patient(
+                MedicationIssues=[
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-02"
+                    ),
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                    ),
+                ],
+                CodedEvents=[
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-02-04"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="mtr2", ConsultationDate="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2015-03-05"),
+                ],
+            ),
+        ]
+    )
+    session.commit()
+    foo_codes = codelist(["ab12"], "snomed")
+    bar_codes = codelist(["bar1", "bar2"], "ctv3")
+    study = StudyDefinition(
+        population=patients.all(),
+        episode_count=patients.with_these_medications(
+            foo_codes,
+            on_or_before="2020-01-01",
+            ignore_days_where_these_clinical_codes_occur=bar_codes,
+            returning="number_of_episodes",
+            episode_defined_as="series of events each <= 14 days apart",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["episode_count"] for i in results] == ["3", "0"]
+
+
 def test_patients_with_tpp_vaccination_record():
     session = make_session()
     vaccines = [

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -59,7 +59,7 @@ class MedicationIssue(Base):
     StartDate = Column(DateTime)
     EndDate = Column(DateTime)
     MedicationStatus = Column(String)
-    ConsultationDate = Column(String)
+    ConsultationDate = Column(DateTime)
 
 
 class MedicationDictionary(Base):


### PR DESCRIPTION
This is essentially the same logic as we support for clinical events. An
example query looks like:
```py
study = StudyDefinition(
    population=patients.all(),
    episode_count=patients.with_these_medications(
        oral_steroid_codes,
        on_or_before="2020-01-01",
        ignore_days_where_these_clinical_codes_occur=annual_review_codes,
        returning="number_of_episodes",
        episode_defined_as="series of events each <= 14 days apart",
    ),
)
```