### PR TITLE
Support querying Care Homes table

### DIFF
--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -198,9 +198,7 @@ class Organisation(Base):
 class PatientAddress(Base):
     __tablename__ = "PatientAddress"
 
-    # This column isn't in the actual database but SQLAlchemy gets a bit upset
-    # if we don't give it a primary key
-    id = Column(Integer, primary_key=True)
+    PatientAddress_ID = Column(Integer, primary_key=True)
     Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
     Patient = relationship("Patient", back_populates="Addresses", cascade="all, delete")
     StartDate = Column(Date)
@@ -209,6 +207,11 @@ class PatientAddress(Base):
     RuralUrbanClassificationCode = Column(Integer)
     ImdRankRounded = Column(Integer)
     MSOACode = Column(String)
+    PotentialCareHomeAddress = relationship(
+        "PotentialCareHomeAddress",
+        back_populates="PatientAddress",
+        cascade="all, delete, delete-orphan",
+    )
 
 
 class ICNARC(Base):
@@ -356,3 +359,24 @@ class SGSS_Positive(Base):
     #   Patient_Sex
     #   County_Description
     #   PostCode_Source
+
+
+class PotentialCareHomeAddress(Base):
+    __tablename__ = "PotentialCareHomeAddress"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    PatientAddress_ID = Column(Integer, ForeignKey("PatientAddress.PatientAddress_ID"))
+    PatientAddress = relationship(
+        "PatientAddress",
+        back_populates="PotentialCareHomeAddress",
+        cascade="all, delete",
+    )
+    # Conceptually these two are a single boolean column but they stored as
+    # separate string columns containing either a Y or an N as this directly
+    # reflects what's in the underlying data source
+    LocationRequiresNursing = Column(String)
+    LocationDoesNotRequireNursing = Column(String)


### PR DESCRIPTION
TPP have attempted to match patient addresses to care homes as stored in
the CQC database. At its most simple the `care_home_status` query
returns a boolean indicating whether the patient's address (as of the
supplied time) matched with a care home.

It is also possible to return a more complex categorisation based on
attributes of the care homes in the CQC database, which can be freely
downloaded here:
https://www.cqc.org.uk/about-us/transparency/using-cqc-data

At present the only imported fields are:
    LocationRequiresNursing
    LocationDoesNotRequireNursing

But we can ask for more fields to be imported if needed.

The `categorised_as` argument acts in effectively the same way as for
the `categorised_as` function except that the only columns that can be
referred to are those belonging to the care home table (i.e. the two
nursing fields above) and the boolean `IsPotentialCareHome`.

Example queries:
```py
is_in_care_home=patients.care_home_status_as_of("2020-01-01")

care_home_type=patients.care_home_status_as_of(
    "2020-01-01",
    categorised_as={
        "PC": """
          IsPotentialCareHome
          AND LocationDoesNotRequireNursing='Y'
          AND LocationRequiresNursing='N'
        """,
        "PN": """
          IsPotentialCareHome
          AND LocationDoesNotRequireNursing='N'
          AND LocationRequiresNursing='Y'
        """,
        "PS": "IsPotentialCareHome",
        "U": "DEFAULT",
    },
)
```