### PR TITLE
Fix string comparison bug

### DIFF
--- a/datalab_cohorts/dashboards/vaccinations_combine.py
+++ b/datalab_cohorts/dashboards/vaccinations_combine.py
@@ -95,7 +95,7 @@ class LeftJoinSortedRows:
     def __init__(self, left_rows, right_rows, on="id"):
         self.left_iter = iter(left_rows)
         self.right_iter = iter(right_rows)
-        self.on = on
+        self.get_key = lambda item: int(item[on])
         self.right_item = next(self.right_iter, None)
 
     def __iter__(self):
@@ -103,7 +103,7 @@ class LeftJoinSortedRows:
 
     def __next__(self):
         left_item = next(self.left_iter)
-        left_key = left_item[self.on]
+        left_key = self.get_key(left_item)
         right_item = self.next_right_item(left_key)
         return left_item, right_item
 
@@ -112,7 +112,7 @@ class LeftJoinSortedRows:
             # No more right items remaining: return None
             if self.right_item is None:
                 return
-            right_key = self.right_item[self.on]
+            right_key = self.get_key(self.right_item)
             # Keys match: this is the item we want
             if right_key == left_key:
                 return self.right_item

--- a/tests/dashboards/test_vaccinations_combine.py
+++ b/tests/dashboards/test_vaccinations_combine.py
@@ -5,18 +5,18 @@ from datalab_cohorts.dashboards.vaccinations_combine import (
 
 def test_add_patient_vaccination_dates():
     patients = [
-        {"patient_id": 123, "some_field": "some_value"},
-        {"patient_id": 456, "some_field": "some_other_value"},
-        {"patient_id": 789, "some_field": "different_value"},
+        {"patient_id": "91", "some_field": "some_value"},
+        {"patient_id": "456", "some_field": "some_other_value"},
+        {"patient_id": "789", "some_field": "different_value"},
     ]
     vaccination_events = [
-        {"patient_id": 123, "vaccine_name": "menb", "date_given": "2018-01-15"},
+        {"patient_id": "91", "vaccine_name": "menb", "date_given": "2018-01-15"},
         # This second event should be ignored as a duplicate
-        {"patient_id": 123, "vaccine_name": "menb", "date_given": "2018-01-20"},
+        {"patient_id": "91", "vaccine_name": "menb", "date_given": "2018-01-20"},
         # But this one should be included
-        {"patient_id": 123, "vaccine_name": "menb", "date_given": "2018-03-05"},
-        {"patient_id": 789, "vaccine_name": "pcv", "date_given": "2018-08-08"},
-        {"patient_id": 789, "vaccine_name": "pcv", "date_given": "2019-06-10"},
+        {"patient_id": "91", "vaccine_name": "menb", "date_given": "2018-03-05"},
+        {"patient_id": "789", "vaccine_name": "pcv", "date_given": "2018-08-08"},
+        {"patient_id": "789", "vaccine_name": "pcv", "date_given": "2019-06-10"},
     ]
     results = add_patient_vaccination_dates(
         patients, vaccination_events, washout_period=14
@@ -24,16 +24,16 @@ def test_add_patient_vaccination_dates():
     results = list(results)
     assert results == [
         {
-            "patient_id": 123,
+            "patient_id": "91",
             "some_field": "some_value",
             "menb_1": "2018-01-01",
             "menb_2": "2018-03-01",
         },
         # This patient had no vaccine events at all but should still be
         # included in the output
-        {"patient_id": 456, "some_field": "some_other_value"},
+        {"patient_id": "456", "some_field": "some_other_value"},
         {
-            "patient_id": 789,
+            "patient_id": "789",
             "some_field": "different_value",
             "pcv_1": "2018-08-01",
             "pcv_2": "2019-06-01",


### PR DESCRIPTION
We're comparing patient IDs which are supposed to be ints but which come
out of the CSV files as strings. This means that they don't compare in
the correct order (e.g. "11" < "9") which leads to failures in the join.