### PR TITLE
Add ACME backend

### DIFF
--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -111,11 +111,10 @@ class ACMEBackend:
         """
         prepared_sql = ["-- Create codelist tables"]
         for sql in self.codelist_tables:
-            prepared_sql.append(f"{sql}\n\n")
+            prepared_sql.append(f"{sql};\n\n")
         for name, query in self.queries:
             prepared_sql.append(f"-- Query for {name}")
-            prepared_sql.append(query)
-            prepared_sql.append("\n\n")
+            prepared_sql.append(f"{query};\n\n")
         return "\n".join(prepared_sql)
 
     def get_queries(self, covariate_definitions):

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -439,7 +439,10 @@ class ACMEBackend:
         sql = f"""
         SELECT
           patients.Patient_ID AS patient_id,
-          ROUND(COALESCE(weight/SQUARE(NULLIF(height, 0)), bmis.BMI), 1) AS BMI,
+          CASE
+            WHEN height = 0 THEN NULL
+            ELSE ROUND(COALESCE(weight/(height*height), bmis.BMI), 1)
+          END AS BMI,
           CASE
             WHEN weight IS NULL OR height IS NULL THEN DATE(bmis.ConsultationDate)
             ELSE DATE(weights.ConsultationDate)

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -302,6 +302,7 @@ class ACMEBackend:
         # is >=16, weight must be within the last 10 years
         date_condition = make_date_filter('"effective-date"', between)
 
+        # TODO Change these to SNOMED codes
         bmi_code = "22K.."
         # XXX these two sets of codes need validating. The final in
         # each list is the canonical version according to TPP

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -344,9 +344,7 @@ class ACMEBackend:
             f"""
             SELECT Patient_ID, 1 AS is_included
             FROM Patient
-            WHERE (ABS(CAST(
-            (BINARY_CHECKSUM(*) *
-            RAND()) as int)) % 100) < {quote(percent)}
+            WHERE (random() * 100) < {quote(percent)}
             """,
         )
 

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -1,0 +1,1421 @@
+import csv
+import datetime
+import enum
+import os
+import re
+import subprocess
+import tempfile
+
+from .expressions import format_expression
+from .presto_utils import (
+    presto_connection_params_from_url,
+    presto_connection_from_url,
+)
+
+
+# Characters that are safe to interpolate into SQL (see
+# `placeholders_and_params` below)
+SAFE_CHARS_RE = re.compile(r"^[a-zA-Z0-9_\.\-]+$")
+
+
+class ACMEBackend:
+    _db_connection = None
+    _current_column_name = None
+
+    def __init__(self, database_url, covariate_definitions):
+        self.database_url = database_url
+        self.covariate_definitions = covariate_definitions
+        self.codelist_tables = []
+        self.queries = self.get_queries(self.covariate_definitions)
+
+    def _to_csv_with_sqlcmd(self, filename):
+        unique_check = UniqueCheck()
+        sql = "SET NOCOUNT ON; "  # don't output count after table output
+        sql += self.to_sql()
+        sqlfile = tempfile.mktemp(suffix=".sql")
+        with open(sqlfile, "w") as f:
+            f.write(sql)
+        temp_csv = tempfile.mktemp(suffix=".csv")
+        db_dict = presto_connection_params_from_url(self.database_url)
+        cmd = [
+            "sqlcmd",
+            "-S",
+            db_dict["host"] + "," + str(db_dict["port"]),
+            "-d",
+            db_dict["database"],
+            "-U",
+            db_dict["username"],
+            "-P",
+            db_dict["password"],
+            "-i",
+            sqlfile,
+            "-W",  # strip whitespace
+            "-s",
+            ",",  # comma delimited
+            "-r",
+            "1",  # error messages to stderr
+            # "-w",
+            # "99",
+            "-o",
+            temp_csv,
+        ]
+        try:
+            subprocess.run(cmd, capture_output=True, encoding="utf8", check=True)
+        except subprocess.CalledProcessError as e:
+            print(e.output)
+            raise
+
+        with open(filename, "w", newline="\r\n") as final_file:
+            # We use windows line endings because that's what
+            # the CSV module's default dialect does
+            for line_num, line in enumerate(open(temp_csv, "r")):
+                if line_num == 0 and line.startswith("Warning"):
+                    continue
+                if line_num <= 2 and line.startswith("-"):
+                    continue
+                final_file.write(line)
+                patient_id = line.split(",")[0]
+                unique_check.add(patient_id)
+        unique_check.assert_unique_ids()
+
+    def to_csv(self, filename, with_sqlcmd=False):
+        if with_sqlcmd:
+            self._to_csv_with_sqlcmd(filename)
+        else:
+            result = self.execute_query()
+            unique_check = UniqueCheck()
+            with open(filename, "w", newline="") as csvfile:
+                writer = csv.writer(csvfile)
+                writer.writerow([x[0] for x in result.description])
+                for row in result:
+                    unique_check.add(row[0])
+                    writer.writerow(row)
+            unique_check.assert_unique_ids()
+
+    def to_dicts(self):
+        result = self.execute_query()
+        keys = [x[0] for x in result.description]
+        # Convert all values to str as that's what will end in the CSV
+        output = [dict(zip(keys, map(str, row))) for row in result]
+        unique_check = UniqueCheck()
+        for item in output:
+            unique_check.add(item["patient_id"])
+        unique_check.assert_unique_ids()
+        return output
+
+    def to_sql(self):
+        """
+        Generate a single SQL string.
+
+        Useful for debugging, optimising, etc.
+        """
+        prepared_sql = ["-- Create codelist tables"]
+        for create_sql, insert_sql, values in self.codelist_tables:
+            prepared_sql.append(create_sql)
+            prepared_sql.append("GO")
+            for row in values:
+                prepared_sql.append(
+                    insert_sql.replace("?", "{}").format(*map(quote, row)) + ";"
+                )
+            prepared_sql.append("GO\n\n")
+        for name, query in self.queries:
+            prepared_sql.append(f"-- Query for {name}")
+            prepared_sql.append(query)
+            prepared_sql.append("\n\n")
+        return "\n".join(prepared_sql)
+
+    def get_queries(self, covariate_definitions):
+        output_columns = {}
+        column_types = {}
+        is_hidden = {}
+        table_queries = {}
+        for name, (query_type, query_args) in covariate_definitions.items():
+            # So we can safely mutate these below
+            query_args = query_args.copy()
+            # These arguments are not used in generating column data and the
+            # corresponding functions do not accept them
+            query_args.pop("return_expectations", None)
+            is_hidden[name] = query_args.pop("hidden", False)
+            column_type = query_args.pop("column_type")
+            # Record the types of columns we've seen so far so that
+            # `categorised_as` expressions can use them if necessary
+            column_types[name] = column_type
+            # `categorised_as` columns don't generate their own table query,
+            # they're just a CASE expression over columns generated by other
+            # queries
+            if query_type == "categorised_as":
+                output_columns[name] = self.get_case_expression(
+                    column_types, output_columns, **query_args
+                )
+            # `value_from` columns also don't generate a table, they just take
+            # a value from another table
+            elif query_type == "value_from":
+                assert query_args["source"] in table_queries
+                output_columns[name] = self.get_column_expression(
+                    column_type, **query_args
+                )
+            else:
+                date_format_args = pop_keys_from_dict(query_args, ["date_format"])
+                cols, sql = self.get_query(name, query_type, query_args)
+                table_queries[name] = f"SELECT * INTO #{name} FROM ({sql}) t"
+                # The first column should always be patient_id so we can join on it
+                assert cols[0] == "patient_id"
+                output_columns[name] = self.get_column_expression(
+                    column_type, name, cols[1], **date_format_args
+                )
+        # If the population query defines its own temporary table then we use
+        # that as the primary table to query against and left join everything
+        # else against that. Otherwise, we use the `Patient` table.
+        if "population" in table_queries:
+            primary_table = "#population"
+            patient_id_expr = "#population.patient_id"
+        else:
+            primary_table = "Patient"
+            patient_id_expr = "Patient.Patient_ID"
+        # Insert `patient_id` as the first column
+        output_columns = dict(patient_id=patient_id_expr, **output_columns)
+        output_columns_str = ",\n          ".join(
+            f"{expr} AS {name}"
+            for (name, expr) in output_columns.items()
+            if not is_hidden.get(name) and name != "population"
+        )
+        joins = [
+            f"LEFT JOIN #{name} ON #{name}.patient_id = {patient_id_expr}"
+            for name in table_queries
+            if name != "population"
+        ]
+        joins_str = "\n          ".join(joins)
+        joined_output_query = f"""
+        SELECT
+          {output_columns_str}
+        FROM
+          {primary_table}
+          {joins_str}
+        WHERE {output_columns["population"]} = 1
+        """
+        return list(table_queries.items()) + [("final_output", joined_output_query)]
+
+    def get_column_expression(self, column_type, source, returning, date_format=None):
+        default_value = self.get_default_value_for_type(column_type)
+        column_expr = f"#{source}.{returning}"
+        if column_type == "date":
+            column_expr = truncate_date(column_expr, date_format)
+        return f"ISNULL({column_expr}, {quote(default_value)})"
+
+    def get_default_value_for_type(self, column_type):
+        if column_type == "date":
+            return ""
+        elif column_type == "str":
+            return ""
+        elif column_type == "bool":
+            return 0
+        elif column_type == "int":
+            return 0
+        elif column_type == "float":
+            return 0.0
+        else:
+            raise ValueError(f"Unhandled column type: {column_type}")
+
+    def execute_query(self):
+        cursor = self.get_db_connection().cursor()
+        self.log("Uploading codelists into temporary tables")
+        for create_sql, insert_sql, values in self.codelist_tables:
+            cursor.execute(create_sql)
+            cursor.executemany(insert_sql, values)
+        queries = list(self.queries)
+        final_query = queries.pop()[1]
+        for name, sql in queries:
+            self.log(f"Running query: {name}")
+            cursor.execute(sql)
+        output_table = self.get_output_table_name(os.environ.get("TEMP_DATABASE_NAME"))
+        if output_table:
+            self.log(f"Running final query and writing output to '{output_table}'")
+            sql = f"SELECT * INTO {output_table} FROM ({final_query}) t"
+            cursor.execute(sql)
+            self.log(f"Downloading data from '{output_table}'")
+            cursor.execute(f"SELECT * FROM {output_table}")
+        else:
+            self.log(
+                "No TEMP_DATABASE_NAME defined in environment, downloading results "
+                "directly without writing to output table"
+            )
+            cursor.execute(final_query)
+        return cursor
+
+    def get_output_table_name(self, temporary_database):
+        if not temporary_database:
+            return
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y%m%d_%H%M%S"
+        )
+        return f"{temporary_database}..Output_{timestamp}"
+
+    def log(self, message):
+        timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        print(f"[{timestamp}] {message}")
+
+    def get_query(self, column_name, query_type, query_args):
+        method_name = f"patients_{query_type}"
+        method = getattr(self, method_name)
+        # Keep track of the current column name for debugging purposes
+        self._current_column_name = column_name
+        return_value = method(**query_args)
+        self._current_column_name = None
+        return return_value
+
+    def create_codelist_table(self, codelist, case_sensitive=True):
+        table_number = len(self.codelist_tables) + 1
+        # We include the current column name for ease of debugging
+        column_name = self._current_column_name or "unknown"
+        # The hash prefix indicates a temporary table
+        table_name = f"#codelist_{table_number}_{column_name}"
+        if codelist.has_categories:
+            values = list(codelist)
+        else:
+            values = [(code, "") for code in codelist]
+        collation = "Latin1_General_BIN" if case_sensitive else "Latin1_General_CI_AS"
+        max_code_len = max(len(code) for (code, category) in values)
+        self.codelist_tables.append(
+            (
+                f"""
+                CREATE TABLE {table_name} (
+                  -- Because some code systems are case-sensitive we need to
+                  -- use a case-sensitive collation here
+                  code VARCHAR({max_code_len}) COLLATE {collation},
+                  category VARCHAR(MAX)
+                )
+                """,
+                f"INSERT INTO {table_name} (code, category) VALUES(?, ?)",
+                values,
+            )
+        )
+        return table_name
+
+    def patients_age_as_of(self, reference_date):
+        quoted_date = quote(reference_date)
+        return (
+            ["patient_id", "age"],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              CASE WHEN
+                 dateadd(year, datediff (year, DateOfBirth, {quoted_date}), DateOfBirth) > {quoted_date}
+              THEN
+                 datediff(year, DateOfBirth, {quoted_date}) - 1
+              ELSE
+                 datediff(year, DateOfBirth, {quoted_date})
+              END AS age
+            FROM Patient
+            """,
+        )
+
+    def patients_sex(self):
+        return (
+            ["patient_id", "sex"],
+            """
+          SELECT
+            Patient_ID AS patient_id,
+            Sex as sex
+          FROM Patient""",
+        )
+
+    def patients_all(self):
+        """
+        All patients
+        """
+        return (
+            ["patient_id", "is_included"],
+            """
+            SELECT Patient_ID AS patient_id, 1 AS is_included
+            FROM Patient
+            """,
+        )
+
+    def patients_random_sample(self, percent):
+        """
+        A random sample of approximately `percent` patients
+        """
+        # See
+        # https://docs.microsoft.com/en-us/previous-versions/software-testing/cc441928(v=msdn.10)?redirectedfrom=MSDN
+        # A TABLESAMPLE clause is more efficient, but its
+        # approximations don't work with small numbers, and we might
+        # want to use this method for small numbers (and certainly do
+        # in the tests!)
+        assert percent, "Must specify a percentage greater than zero"
+        return (
+            ["patient_id", "is_included"],
+            f"""
+            SELECT Patient_ID, 1 AS is_included
+            FROM Patient
+            WHERE (ABS(CAST(
+            (BINARY_CHECKSUM(*) *
+            RAND()) as int)) % 100) < {quote(percent)}
+            """,
+        )
+
+    def patients_most_recent_bmi(
+        self,
+        # Set date limits
+        between=None,
+        minimum_age_at_measurement=16,
+        # Add an additional column indicating when measurement was taken
+        include_date_of_match=False,
+    ):
+        """
+        Return patients' most recent BMI (in the defined period) either
+        computed from weight and height measurements or, where they are not
+        availble, from recorded BMI values. Measurements taken when a patient
+        was below the minimum age are ignored. The height measurement can be
+        taken before (but not after) the defined period as long as the patient
+        was over the minimum age at the time.
+
+        Optionally returns an additional column with the date of the
+        measurement. If the BMI is computed from weight and height then we use
+        the date of the weight measurement for this.
+        """
+        # From https://github.com/ebmdatalab/tpp-sql-notebook/issues/10:
+        #
+        # 1) BMI calculated from last recorded height and weight
+        #
+        # 2) If height and weight is not available, then take latest
+        # recorded BMI. Both values must be recorded when the patient
+        # is >=16, weight must be within the last 10 years
+        date_condition = make_date_filter("ConsultationDate", between)
+
+        bmi_code = "22K.."
+        # XXX these two sets of codes need validating. The final in
+        # each list is the canonical version according to TPP
+        weight_codes = [
+            "X76C7",  # Concept containing "body weight" terms:
+            "22A..",  # O/E weight
+        ]
+        height_codes = [
+            "XM01E",  # Concept containing height/length/stature/growth terms:
+            "229..",  # O/E height
+        ]
+
+        bmi_cte = f"""
+        SELECT t.Patient_ID, t.BMI, t.ConsultationDate
+        FROM (
+          SELECT Patient_ID, NumericValue AS BMI, ConsultationDate,
+          ROW_NUMBER() OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate DESC) AS rownum
+          FROM CodedEvent
+          WHERE CTV3Code = {quote(bmi_code)} AND {date_condition}
+        ) t
+        WHERE t.rownum = 1
+        """
+
+        patients_cte = """
+           SELECT Patient_ID, DateOfBirth
+           FROM Patient
+        """
+        weight_codes_sql = codelist_to_sql(weight_codes)
+        weights_cte = f"""
+          SELECT t.Patient_ID, t.weight, t.ConsultationDate
+          FROM (
+            SELECT Patient_ID, NumericValue AS weight, ConsultationDate,
+            ROW_NUMBER() OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate DESC) AS rownum
+            FROM CodedEvent
+            WHERE CTV3Code IN ({weight_codes_sql}) AND {date_condition}
+          ) t
+          WHERE t.rownum = 1
+        """
+
+        height_codes_sql = codelist_to_sql(height_codes)
+        # The height date restriction is different from the others. We don't
+        # mind using old values as long as the patient was old enough when they
+        # were taken.
+        height_date_condition = make_date_filter(
+            "ConsultationDate", between, upper_bound_only=True,
+        )
+        heights_cte = f"""
+          SELECT t.Patient_ID, t.height, t.ConsultationDate
+          FROM (
+            SELECT Patient_ID, NumericValue AS height, ConsultationDate,
+            ROW_NUMBER() OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate DESC) AS rownum
+            FROM CodedEvent
+            WHERE CTV3Code IN ({height_codes_sql}) AND {height_date_condition}
+          ) t
+          WHERE t.rownum = 1
+        """
+
+        min_age = int(minimum_age_at_measurement)
+
+        sql = f"""
+        SELECT
+          patients.Patient_ID AS patient_id,
+          ROUND(COALESCE(weight/SQUARE(NULLIF(height, 0)), bmis.BMI), 1) AS BMI,
+          CASE
+            WHEN weight IS NULL OR height IS NULL THEN bmis.ConsultationDate
+            ELSE weights.ConsultationDate
+          END AS date
+        FROM ({patients_cte}) AS patients
+        LEFT JOIN ({weights_cte}) AS weights
+        ON weights.Patient_ID = patients.Patient_ID AND DATEDIFF(YEAR, patients.DateOfBirth, weights.ConsultationDate) >= {min_age}
+        LEFT JOIN ({heights_cte}) AS heights
+        ON heights.Patient_ID = patients.Patient_ID AND DATEDIFF(YEAR, patients.DateOfBirth, heights.ConsultationDate) >= {min_age}
+        LEFT JOIN ({bmi_cte}) AS bmis
+        ON bmis.Patient_ID = patients.Patient_ID AND DATEDIFF(YEAR, patients.DateOfBirth, bmis.ConsultationDate) >= {min_age}
+        -- XXX maybe add a "WHERE NULL..." here
+        """
+        columns = ["patient_id", "BMI"]
+        if include_date_of_match:
+            columns.append("date")
+        return columns, sql
+
+    def patients_mean_recorded_value(
+        self,
+        codelist,
+        # What period is the mean over? (Only one supported option for now)
+        on_most_recent_day_of_measurement=None,
+        # Set date limits
+        between=None,
+        # Add additional columns indicating when measurement was taken
+        include_date_of_match=False,
+    ):
+        # We only support this option for now
+        assert on_most_recent_day_of_measurement
+        date_condition = make_date_filter("ConsultationDate", between)
+        codelist_sql = codelist_to_sql(codelist)
+        # The subquery finds, for each patient, the most recent day on which
+        # they've had a measurement. The outer query selects, for each patient,
+        # the mean value on that day.
+        # Note, there's a CAST in the JOIN condition but apparently SQL Server can still
+        # use an index for this. See: https://stackoverflow.com/a/25564539
+        sql = f"""
+        SELECT
+          days.Patient_ID AS patient_id,
+          AVG(CodedEvent.NumericValue) AS mean_value,
+          days.date_measured AS date
+        FROM (
+            SELECT Patient_ID, CAST(MAX(ConsultationDate) AS date) AS date_measured
+            FROM CodedEvent
+            WHERE CTV3Code IN ({codelist_sql}) AND {date_condition}
+            GROUP BY Patient_ID
+        ) AS days
+        LEFT JOIN CodedEvent
+        ON (
+          CodedEvent.Patient_ID = days.Patient_ID
+          AND CodedEvent.CTV3Code IN ({codelist_sql})
+          AND CAST(CodedEvent.ConsultationDate AS date) = days.date_measured
+        )
+        GROUP BY days.Patient_ID, days.date_measured
+        """
+        columns = ["patient_id", "mean_value"]
+        if include_date_of_match:
+            columns.append("date")
+        return columns, sql
+
+    def patients_registered_as_of(self, reference_date):
+        """
+        All patients registed on the given date
+        """
+        return self.patients_registered_with_one_practice_between(
+            reference_date, reference_date
+        )
+
+    def patients_registered_with_one_practice_between(self, start_date, end_date):
+        """
+        All patients registered with the same practice through the given period
+        """
+        # Note that current registrations are recorded with an EndDate
+        # of 9999-12-31
+        return (
+            ["patient_id", "is_registered"],
+            f"""
+            SELECT DISTINCT Patient.Patient_ID AS patient_id, 1 AS is_registered
+            FROM Patient
+            INNER JOIN RegistrationHistory
+            ON RegistrationHistory.Patient_ID = Patient.Patient_ID
+            WHERE StartDate <= {quote(start_date)} AND EndDate > {quote(end_date)}
+            """,
+        )
+
+    def patients_with_complete_history_between(self, start_date, end_date):
+        """
+        All patients for which we have a full set of records between the given
+        dates
+        """
+        # This should be do-able by checking for a contiguous set of
+        # RegistrationHistory entries covering the period. There's a further
+        # complication though which is that a practice might not have been
+        # using SystmOne at the point where the patient registered so we can
+        # only guarantee data from the point where the patient was registred
+        # *and* the practice was on SystmOne. Apparently the Organisation table
+        # now has a TPP go-live date which we can use for this purpose.
+        raise NotImplementedError()
+
+    def patients_with_these_medications(self, **kwargs):
+        """
+        Patients who have been prescribed at least one of this list of
+        medications in the defined period
+        """
+        # Note that we're using "ConsultationDate" for the date condition here,
+        # which is the date of prescription.  The MedicationIssue table also
+        # has StartDate (the date of issue) and EndDate (not exactly sure what
+        # this is).
+        assert kwargs["codelist"].system == "snomed"
+        if kwargs["returning"] == "numeric_value":
+            raise ValueError("Unsupported `returning` value: numeric_value")
+        # This uses a special case function with a "fake it til you make it" API
+        if kwargs["returning"] == "number_of_episodes":
+            kwargs.pop("returning")
+            # Remove unhandled arguments and check they are unused
+            assert not kwargs.pop("find_first_match_in_period", None)
+            assert not kwargs.pop("find_last_match_in_period", None)
+            assert not kwargs.pop("include_date_of_match", None)
+            return self._number_of_episodes_by_medication(**kwargs)
+        # This is the default code path for most queries
+        else:
+            # Remove unhandled arguments and check they are unused
+            assert not kwargs.pop("episode_defined_as", None)
+            return self._patients_with_events(
+                "MedicationIssue",
+                """
+                INNER JOIN MedicationDictionary
+                ON MedicationIssue.MultilexDrug_ID = MedicationDictionary.MultilexDrug_ID
+                """,
+                "DMD_ID",
+                codes_are_case_sensitive=False,
+                **kwargs,
+            )
+
+    def patients_with_these_clinical_events(self, **kwargs):
+        """
+        Patients who have had at least one of these clinical events in the
+        defined period
+        """
+        assert kwargs["codelist"].system == "ctv3"
+        # This uses a special case function with a "fake it til you make it" API
+        if kwargs["returning"] == "number_of_episodes":
+            kwargs.pop("returning")
+            # Remove unhandled arguments and check they are unused
+            assert not kwargs.pop("find_first_match_in_period", None)
+            assert not kwargs.pop("find_last_match_in_period", None)
+            assert not kwargs.pop("include_date_of_match", None)
+            return self._number_of_episodes_by_clinical_event(**kwargs)
+        # This is the default code path for most queries
+        else:
+            assert not kwargs.pop("episode_defined_as", None)
+            return self._patients_with_events(
+                "CodedEvent", "", "CTV3Code", codes_are_case_sensitive=True, **kwargs
+            )
+
+    def _patients_with_events(
+        self,
+        from_table,
+        additional_join,
+        code_column,
+        codes_are_case_sensitive,
+        codelist,
+        # Allows us to say: find codes A and B, but only on days where X and Y
+        # didn't happen
+        ignore_days_where_these_codes_occur=None,
+        # Set date limits
+        between=None,
+        # Matching rule
+        find_first_match_in_period=None,
+        find_last_match_in_period=None,
+        # Set return type
+        returning="binary_flag",
+        include_date_of_match=False,
+    ):
+        codelist_table = self.create_codelist_table(codelist, codes_are_case_sensitive)
+        date_condition = make_date_filter("ConsultationDate", between)
+        not_an_ignored_day_condition = self._none_of_these_codes_occur_on_same_day(
+            from_table, ignore_days_where_these_codes_occur
+        )
+
+        # Result ordering
+        if find_first_match_in_period:
+            ordering = "ASC"
+            date_aggregate = "MIN"
+        else:
+            ordering = "DESC"
+            date_aggregate = "MAX"
+
+        if returning == "binary_flag" or returning == "date":
+            column_name = "has_event"
+            column_definition = "1"
+            use_partition_query = False
+        elif returning == "number_of_matches_in_period":
+            column_name = "count"
+            column_definition = "COUNT(*)"
+            use_partition_query = False
+        elif returning == "numeric_value":
+            column_name = "value"
+            column_definition = "NumericValue"
+            use_partition_query = True
+        elif returning == "code":
+            column_name = "code"
+            column_definition = code_column
+            use_partition_query = True
+        elif returning == "category":
+            if not codelist.has_categories:
+                raise ValueError(
+                    "Cannot return categories because the supplied codelist does "
+                    "not have any categories defined"
+                )
+            column_name = "category"
+            column_definition = "category"
+            use_partition_query = True
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+
+        if use_partition_query:
+            sql = f"""
+            SELECT
+              Patient_ID AS patient_id,
+              {column_definition} AS {column_name},
+              ConsultationDate AS date
+            FROM (
+              SELECT Patient_ID, {column_definition}, ConsultationDate,
+              ROW_NUMBER() OVER (
+                PARTITION BY Patient_ID ORDER BY ConsultationDate {ordering}
+              ) AS rownum
+              FROM {from_table}{additional_join}
+              INNER JOIN {codelist_table}
+              ON {code_column} = {codelist_table}.code
+              WHERE {date_condition} AND {not_an_ignored_day_condition}
+            ) t
+            WHERE rownum = 1
+            """
+        else:
+            sql = f"""
+            SELECT
+              Patient_ID AS patient_id,
+              {column_definition} AS {column_name},
+              {date_aggregate}(ConsultationDate) AS date
+            FROM {from_table}{additional_join}
+            INNER JOIN {codelist_table}
+            ON {code_column} = {codelist_table}.code
+            WHERE {date_condition} AND {not_an_ignored_day_condition}
+            GROUP BY Patient_ID
+            """
+
+        if returning == "date":
+            columns = ["patient_id", "date"]
+        else:
+            columns = ["patient_id", column_name]
+            if include_date_of_match:
+                columns.append("date")
+        return columns, sql
+
+    def _number_of_episodes_by_medication(
+        self,
+        codelist,
+        # Set date limits
+        between=None,
+        ignore_days_where_these_codes_occur=None,
+        episode_defined_as=None,
+    ):
+        codelist_table = self.create_codelist_table(codelist, case_sensitive=False)
+        date_condition = make_date_filter("ConsultationDate", between)
+        not_an_ignored_day_condition = self._none_of_these_codes_occur_on_same_day(
+            "MedicationIssue", ignore_days_where_these_codes_occur
+        )
+        if episode_defined_as is not None:
+            pattern = r"^series of events each <= (\d+) days apart$"
+            match = re.match(pattern, episode_defined_as)
+            if not match:
+                raise ValueError(
+                    f"Argument `episode_defined_as` must match " f"pattern: {pattern}"
+                )
+            washout_period = int(match.group(1))
+        else:
+            washout_period = 0
+
+        sql = f"""
+        SELECT
+          Patient_ID AS patient_id,
+          SUM(is_new_episode) AS episode_count
+        FROM (
+            SELECT
+              Patient_ID,
+              CASE
+                WHEN
+                  DATEDIFF(
+                    day,
+                    LAG(ConsultationDate) OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate),
+                    ConsultationDate
+                  ) <= {washout_period}
+                THEN 0
+                ELSE 1
+              END AS is_new_episode
+            FROM MedicationIssue
+            INNER JOIN MedicationDictionary
+            ON MedicationIssue.MultilexDrug_ID = MedicationDictionary.MultilexDrug_ID
+            INNER JOIN {codelist_table}
+            ON DMD_ID = {codelist_table}.code
+            WHERE {date_condition} AND {not_an_ignored_day_condition}
+        ) t
+        GROUP BY Patient_ID
+        """
+        return ["patient_id", "episode_count"], sql
+
+    def _number_of_episodes_by_clinical_event(
+        self,
+        codelist,
+        # Set date limits
+        between=None,
+        ignore_days_where_these_codes_occur=None,
+        episode_defined_as=None,
+    ):
+        codelist_table = self.create_codelist_table(codelist, case_sensitive=True)
+        date_condition = make_date_filter("ConsultationDate", between)
+        not_an_ignored_day_condition = self._none_of_these_codes_occur_on_same_day(
+            "CodedEvent", ignore_days_where_these_codes_occur
+        )
+        if episode_defined_as is not None:
+            pattern = r"^series of events each <= (\d+) days apart$"
+            match = re.match(pattern, episode_defined_as)
+            if not match:
+                raise ValueError(
+                    f"Argument `episode_defined_as` must match " f"pattern: {pattern}"
+                )
+            washout_period = int(match.group(1))
+        else:
+            washout_period = 0
+
+        sql = f"""
+        SELECT
+          Patient_ID AS patient_id,
+          SUM(is_new_episode) AS episode_count
+        FROM (
+            SELECT
+              Patient_ID,
+              CASE
+                WHEN
+                  DATEDIFF(
+                    day,
+                    LAG(ConsultationDate) OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate),
+                    ConsultationDate
+                  ) <= {washout_period}
+                THEN 0
+                ELSE 1
+              END AS is_new_episode
+            FROM CodedEvent
+            INNER JOIN {codelist_table}
+            ON CTV3Code = {codelist_table}.code
+            WHERE {date_condition} AND {not_an_ignored_day_condition}
+        ) t
+        GROUP BY Patient_ID
+        """
+        return ["patient_id", "episode_count"], sql
+
+    def _none_of_these_codes_occur_on_same_day(self, joined_table, codelist):
+        """
+        Generates a SQL condition that filters rows in `joined_table` so that
+        they only include events which happened on days where none of the codes
+        in `codelist` occur in the CodedEvents table.
+
+        We use this to support queries like "give me all the times a patient
+        was prescribed this drug, but ignore any days on which they were having
+        their annual COPD review".
+        """
+        if codelist is None:
+            return "1 = 1"
+        assert codelist.system == "ctv3"
+        codelist_table = self.create_codelist_table(codelist, case_sensitive=True)
+        return f"""
+        NOT EXISTS (
+          SELECT * FROM CodedEvent AS sameday
+          INNER JOIN {codelist_table}
+          ON sameday.CTV3Code = {codelist_table}.code
+          WHERE
+            sameday.Patient_ID = {joined_table}.Patient_ID
+            AND CAST(sameday.ConsultationDate AS date) = CAST({joined_table}.ConsultationDate AS date)
+        )
+        """
+
+    def patients_registered_practice_as_of(self, date, returning=None):
+        if returning == "stp_code":
+            column = "STPCode"
+        elif returning == "msoa_code":
+            column = "MSOACode"
+        elif returning == "nhse_region_name":
+            column = "Region"
+        elif returning == "pseudo_id":
+            column = "Organisation_ID"
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+        # Note that current registrations are recorded with an EndDate of
+        # 9999-12-31. Where registration periods overlap we use the one with
+        # the most recent start date. If there are several with the same start
+        # date we use the longest one (i.e. with the latest end date).
+        return (
+            ["patient_id", returning],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              Organisation.{column} AS {returning}
+            FROM (
+              SELECT Patient_ID, Organisation_ID,
+              ROW_NUMBER() OVER (
+                PARTITION BY Patient_ID ORDER BY StartDate DESC, EndDate DESC
+              ) AS rownum
+              FROM RegistrationHistory
+              WHERE StartDate <= {quote(date)} AND EndDate > {quote(date)}
+            ) t
+            LEFT JOIN Organisation
+            ON Organisation.Organisation_ID = t.Organisation_ID
+            WHERE t.rownum = 1
+            """,
+        )
+
+    def patients_address_as_of(self, date, returning=None, round_to_nearest=None):
+        # N.B. A value of -1 indicates no postcode recorded on the
+        # record, an invalid postcode, or no fixed abode.
+        #
+        # Related, there is a column in the address table to indicate
+        # NP for no postcode or NFA for no fixed abode
+        if returning == "index_of_multiple_deprivation":
+            assert round_to_nearest == 100
+            column = "ImdRankRounded"
+        elif returning == "rural_urban_classification":
+            assert round_to_nearest is None
+            column = "RuralUrbanClassificationCode"
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+        # Note that current addresses are recorded with an EndDate of
+        # 9999-12-31. Where address periods overlap we use the one with the
+        # most recent start date. If there are several with the same start date
+        # we use the longest one (i.e. with the latest end date).
+        return (
+            ["patient_id", returning],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              {column} AS {returning}
+            FROM (
+              SELECT Patient_ID, {column},
+              ROW_NUMBER() OVER (
+                PARTITION BY Patient_ID ORDER BY StartDate DESC, EndDate DESC
+              ) AS rownum
+              FROM PatientAddress
+              WHERE StartDate <= {quote(date)} AND EndDate > {quote(date)}
+            ) t
+            WHERE rownum = 1
+            """,
+        )
+
+    def patients_care_home_status_as_of(self, date, categorised_as):
+        # These are the columns to which the categorisation expression is
+        # allowed to refer
+        allowed_columns = {
+            "IsPotentialCareHome": "ISNULL(PotentialCareHomeAddressID, 0)",
+            "LocationRequiresNursing": "LocationRequiresNursing",
+            "LocationDoesNotRequireNursing": "LocationDoesNotRequireNursing",
+        }
+        allowed_column_types = {
+            "IsPotentialCareHome": "int",
+            "LocationRequiresNursing": "str",
+            "LocationDoesNotRequireNursing": "str",
+        }
+        case_expression = self.get_case_expression(
+            allowed_column_types, allowed_columns, categorised_as
+        )
+        return (
+            ["patient_id", "value"],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              {case_expression} AS value
+            FROM (
+              SELECT
+                PatientAddress.Patient_ID AS Patient_ID,
+                PotentialCareHomeAddress.PatientAddress_ID AS PotentialCareHomeAddressID,
+                LocationRequiresNursing,
+                LocationDoesNotRequireNursing,
+                ROW_NUMBER() OVER (
+                  PARTITION BY PatientAddress.Patient_ID ORDER BY StartDate DESC, EndDate DESC
+                ) AS rownum
+              FROM PatientAddress
+              LEFT JOIN PotentialCareHomeAddress
+              ON PatientAddress.PatientAddress_ID = PotentialCareHomeAddress.PatientAddress_ID
+              WHERE StartDate <= {quote(date)} AND EndDate > {quote(date)}
+            ) t
+            WHERE rownum = 1
+            """,
+        )
+
+    # https://github.com/ebmdatalab/tpp-sql-notebook/issues/72
+    def patients_admitted_to_icu(
+        self,
+        between=None,
+        find_first_match_in_period=None,
+        find_last_match_in_period=None,
+        returning="binary_flag",
+    ):
+        if find_first_match_in_period:
+            date_aggregate = "MIN"
+            date_column_name = "first_admitted_date"
+        else:
+            date_aggregate = "MAX"
+            date_column_name = "last_admitted_date"
+        date_expression = f"""
+        {date_aggregate}(
+        CASE
+        WHEN
+          COALESCE(IcuAdmissionDateTime, '9999-01-01') < COALESCE(OriginalIcuAdmissionDate, '9999-01-01')
+        THEN
+          IcuAdmissionDateTime
+        ELSE
+          OriginalIcuAdmissionDate
+        END)"""
+        date_condition = make_date_filter(date_expression, between)
+
+        if returning == "date_admitted":
+            column_name = date_column_name
+            column_definition = date_expression
+        elif returning == "binary_flag":
+            column_name = "was_admitted"
+            column_definition = 1
+        else:
+            assert False, "`returning` must be one of `binary_flag` or `date_admitted`"
+        return (
+            ["patient_id", column_name],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              {column_definition} AS {column_name},
+              MAX(Ventilator) AS ventilated -- apparently can be 0, 1 or NULL
+            FROM
+              ICNARC
+            GROUP BY Patient_ID
+            HAVING
+              {date_condition} AND SUM(BasicDays_RespiratorySupport) + SUM(AdvancedDays_RespiratorySupport) >= 1
+            """,
+        )
+
+    def patients_with_these_codes_on_death_certificate(
+        self,
+        codelist=None,
+        # Set date limits
+        between=None,
+        # Matching rules
+        match_only_underlying_cause=False,
+        # Set return type
+        returning="binary_flag",
+    ):
+        date_condition = make_date_filter("dod", between)
+        if codelist is not None:
+            assert codelist.system == "icd10"
+            codelist_sql = codelist_to_sql(codelist)
+            code_columns = ["icd10u"]
+            if not match_only_underlying_cause:
+                code_columns.extend([f"ICD10{i:03d}" for i in range(1, 16)])
+            code_conditions = " OR ".join(
+                f"{column} IN ({codelist_sql})" for column in code_columns
+            )
+        else:
+            code_conditions = "1 = 1"
+        if returning == "binary_flag":
+            column_definition = "1"
+            column_name = "died"
+        elif returning == "date_of_death":
+            column_definition = "dod"
+            column_name = "date_of_death"
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+        return (
+            ["patient_id", column_name],
+            f"""
+            SELECT Patient_ID as patient_id, {column_definition} AS {column_name}
+            FROM ONS_Deaths
+            WHERE ({code_conditions}) AND {date_condition}
+            """,
+        )
+
+    def patients_died_from_any_cause(
+        self,
+        # Set date limits
+        between=None,
+        # Set return type
+        returning="binary_flag",
+    ):
+        return self.patients_with_these_codes_on_death_certificate(
+            codelist=None, between=between, returning=returning,
+        )
+
+    def patients_with_death_recorded_in_cpns(
+        self,
+        # Set date limits
+        between=None,
+        # Set return type
+        returning="binary_flag",
+    ):
+        date_condition = make_date_filter("DateOfDeath", between)
+        if returning == "binary_flag":
+            column_definition = "1"
+            column_name = "died"
+        elif returning == "date_of_death":
+            column_definition = "MAX(DateOfDeath)"
+            column_name = "date_of_death"
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+        return (
+            ["patient_id", column_name],
+            f"""
+            SELECT
+              Patient_ID as patient_id,
+              {column_definition} AS {column_name},
+              -- Crude error check so we blow up in the case of inconsistent dates
+              1 / CASE WHEN MAX(DateOfDeath) = MIN(DateOfDeath) THEN 1 ELSE 0 END AS _e
+            FROM CPNS
+            WHERE {date_condition}
+            GROUP BY Patient_ID
+            """,
+        )
+
+    def patients_with_tpp_vaccination_record(
+        self,
+        target_disease_matches=None,
+        product_name_matches=None,
+        # Set date limits
+        between=None,
+        # Set return type
+        returning="binary_flag",
+        # Matching rule
+        find_first_match_in_period=None,
+        find_last_match_in_period=None,
+        include_date_of_match=False,
+    ):
+        conditions = [make_date_filter("VaccinationDate", between)]
+        target_disease_matches = to_list(target_disease_matches)
+        if target_disease_matches:
+            content_codes = codelist_to_sql(target_disease_matches)
+            conditions.append(f"ref.VaccinationContent IN ({content_codes})")
+
+        product_name_matches = to_list(product_name_matches)
+        if product_name_matches:
+            product_name_codes = codelist_to_sql(product_name_matches)
+            conditions.append(f"ref.VaccinationName IN ({product_name_codes})")
+
+        conditions_str = " AND ".join(conditions)
+
+        # Result ordering
+        if find_first_match_in_period:
+            date_aggregate = "MIN"
+        else:
+            date_aggregate = "MAX"
+
+        if returning == "binary_flag" or returning == "date":
+            column_name = "has_event"
+            column_definition = "1"
+        else:
+            # Because each Vaccination row can potentially map to multiple
+            # VaccinationReference rows (one for each disease targeted by the
+            # vaccine) anything beyond a simple binary flag or a date is going to
+            # require more thought.
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+
+        sql = f"""
+        SELECT
+          Patient_ID AS patient_id,
+          {column_definition} AS {column_name},
+          {date_aggregate}(VaccinationDate) AS date
+        FROM Vaccination
+        INNER JOIN VaccinationReference AS ref
+        ON ref.VaccinationName_ID = Vaccination.VaccinationName_ID
+        WHERE {conditions_str}
+        GROUP BY Patient_ID
+        """
+
+        if returning == "date":
+            columns = ["patient_id", "date"]
+        else:
+            columns = ["patient_id", column_name]
+            if include_date_of_match:
+                columns.append("date")
+        return columns, sql
+
+    def patients_with_gp_consultations(
+        self,
+        # Set date limits
+        between=None,
+        # Matching rule
+        find_first_match_in_period=None,
+        find_last_match_in_period=None,
+        # Set return type
+        returning="binary_flag",
+        include_date_of_match=False,
+    ):
+        if returning == "binary_flag" or returning == "date":
+            column_name = "has_event"
+            column_definition = "1"
+        elif returning == "number_of_matches_in_period":
+            column_name = "count"
+            column_definition = "COUNT(*)"
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+
+        valid_states = [
+            AppointmentStatus.ARRIVED,
+            AppointmentStatus.WAITING,
+            AppointmentStatus.IN_PROGRESS,
+            AppointmentStatus.FINISHED,
+            AppointmentStatus.PATIENT_WALKED_OUT,
+            AppointmentStatus.VISIT,
+        ]
+        valid_states_str = codelist_to_sql(map(int, valid_states))
+
+        date_condition = make_date_filter("SeenDate", between)
+        # Result ordering
+        date_aggregate = "MIN" if find_first_match_in_period else "MAX"
+        sql = f"""
+        SELECT
+          Patient_ID AS patient_id,
+          {column_definition} AS {column_name},
+          {date_aggregate}(SeenDate) AS date
+        FROM Appointment
+        WHERE Status IN ({valid_states_str}) AND {date_condition}
+        GROUP BY Patient_ID
+        """
+
+        if returning == "date":
+            columns = ["patient_id", "date"]
+        else:
+            columns = ["patient_id", column_name]
+            if include_date_of_match:
+                columns.append("date")
+        return columns, sql
+
+    def patients_with_complete_gp_consultation_history_between(
+        self, start_date, end_date
+    ):
+        """
+        In this context this should mean patients who have been continuously
+        registered with TPP-using practices throughout this period. However,
+        for now we restrict this to just patients who have been registered with
+        a single practice throughout this period.  As this is a more
+        restrictive condition this is fine for our purposes, however once we
+        get an implementation for `patients_with_complete_history_between` we
+        should switch to using this.
+        """
+        return self.patients_registered_with_one_practice_between(start_date, end_date)
+
+    def patients_with_test_result_in_sgss(
+        self,
+        pathogen=None,
+        test_result=None,
+        # Set date limits
+        between=None,
+        # Matching rule
+        find_first_match_in_period=None,
+        find_last_match_in_period=None,
+        # Set return type
+        returning="binary_flag",
+        include_date_of_match=False,
+    ):
+        assert pathogen == "SARS-CoV-2"
+        assert test_result in ("positive", "negative", "any")
+        if returning not in ("binary_flag", "date"):
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+
+        date_condition = make_date_filter("date", between)
+        date_aggregate = "MIN" if find_first_match_in_period else "MAX"
+        if test_result == "any":
+            result_condition = "1 = 1"
+        else:
+            flag = 1 if test_result == "positive" else 0
+            result_condition = f"test_result = {quote(flag)}"
+
+        # These are the values we're expecting in our SGSS tables. If we ever
+        # get anything other than these we should throw an error rather than
+        # blindly continuing.
+        positive_descr = "SARS-CoV-2 CORONAVIRUS (Covid-19)"
+        negative_descr = "NEGATIVE SARS-CoV-2 (COVID-19)"
+
+        sql = f"""
+        SELECT
+          patient_id,
+          1 AS has_result,
+          {date_aggregate}(date) AS date,
+          -- We have to calculate something over the error check field
+          -- otherwise it never gets computed
+          MAX(_e) AS _e
+        FROM (
+          SELECT
+            1 AS test_result,
+            Patient_ID AS patient_id,
+            Earliest_Specimen_Date AS date,
+            -- Crude error check so we blow up in the case of unexpected data
+            1 / CASE WHEN Organism_Species_Name = '{positive_descr}' THEN 1 ELSE 0 END AS _e
+          FROM SGSS_Positive
+          UNION ALL
+          SELECT
+            0 AS test_result,
+            Patient_ID AS patient_id,
+            Earliest_Specimen_Date AS date,
+            -- Crude error check so we blow up in the case of unexpected data
+            1 / CASE WHEN Organism_Species_Name = '{negative_descr}' THEN 1 ELSE 0 END AS _e
+          FROM SGSS_Negative
+        ) t
+        WHERE {date_condition} AND {result_condition}
+        GROUP BY patient_id
+        """
+
+        if returning == "date":
+            columns = ["patient_id", "date"]
+        else:
+            columns = ["patient_id", "has_result"]
+            if include_date_of_match:
+                columns.append("date")
+        return columns, sql
+
+    def get_case_expression(
+        self, column_types, column_definitions, category_definitions
+    ):
+        category_definitions = category_definitions.copy()
+        defaults = [k for (k, v) in category_definitions.items() if v == "DEFAULT"]
+        if len(defaults) > 1:
+            raise ValueError("At most one default category can be defined")
+        if len(defaults) == 1:
+            default_value = defaults[0]
+            category_definitions.pop(default_value)
+        else:
+            raise ValueError(
+                "At least one category must be given the definition 'DEFAULT'"
+            )
+        # For each column already defined, determine its corresponding "empty"
+        # value (i.e. the default value for that column's type). This allows us
+        # to support implicit boolean conversion because we know what the
+        # "falsey" value for each column should be.
+        empty_value_map = {
+            name: self.get_default_value_for_type(column_type)
+            for name, column_type in column_types.items()
+        }
+        clauses = []
+        for category, expression in category_definitions.items():
+            # The column references in the supplied expression need to be
+            # rewritten to ensure they refer to the correct CTE. The formatting
+            # function also ensures that the expression matches the very
+            # limited subset of SQL we support here.
+            formatted_expression = format_expression(
+                expression, column_definitions, empty_value_map=empty_value_map
+            )
+            clauses.append(f"WHEN ({formatted_expression}) THEN {quote(category)}")
+        return f"CASE {' '.join(clauses)} ELSE {quote(default_value)} END"
+
+    def get_db_connection(self):
+        if self._db_connection:
+            return self._db_connection
+        self._db_connection = presto_connection_from_url(self.database_url)
+        return self._db_connection
+
+
+def codelist_to_sql(codelist):
+    if getattr(codelist, "has_categories", False):
+        values = [quote(code) for (code, category) in codelist]
+    else:
+        values = map(quote, codelist)
+    return ",".join(values)
+
+
+def to_list(value):
+    if value is None:
+        return []
+    if not isinstance(value, (tuple, list)):
+        return [value]
+    return list(value)
+
+
+def standardise_if_date(value):
+    """For strings that look like ISO dates, format in a SQL-Server
+    friendly fashion
+
+    """
+
+    # ISO date strings with hyphens are unreliable in SQL Server:
+    # https://stackoverflow.com/a/25548626/559140
+    try:
+        date = datetime.datetime.strptime(value, "%Y-%m-%d")
+        value = date.strftime("%Y%m%d")
+    except ValueError:
+        pass
+    return value
+
+
+def quote(value):
+    if isinstance(value, (int, float)):
+        return str(value)
+    else:
+        value = str(value)
+        value = standardise_if_date(value)
+        if not SAFE_CHARS_RE.match(value) and value != "":
+            raise ValueError(f"Value contains disallowed characters: {value}")
+        return f"'{value}'"
+
+
+def make_date_filter(column, between, upper_bound_only=False):
+    if between is None:
+        between = (None, None)
+    min_date, max_date = between
+    if upper_bound_only:
+        min_date = None
+    if min_date is not None and max_date is not None:
+        return f"{column} BETWEEN {quote(min_date)} AND {quote(max_date)}"
+    elif min_date is not None:
+        return f"{column} >= {quote(min_date)}"
+    elif max_date is not None:
+        return f"{column} <= {quote(max_date)}"
+    else:
+        return "1=1"
+
+
+def truncate_date(column, date_format):
+    if date_format == "YYYY" or date_format is None:
+        date_length = 4
+    elif date_format == "YYYY-MM":
+        date_length = 7
+    elif date_format == "YYYY-MM-DD":
+        date_length = 10
+    else:
+        raise ValueError(f"Unhandled date format: {date_format}")
+    # Style 23 below means YYYY-MM-DD format, see:
+    # https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15#date-and-time-styles
+    return f"CONVERT(VARCHAR({date_length}), {column}, 23)"
+
+
+class UniqueCheck:
+    def __init__(self):
+        self.count = 0
+        self.ids = set()
+
+    def add(self, item):
+        self.count += 1
+        self.ids.add(item)
+
+    def assert_unique_ids(self):
+        duplicates = self.count - len(self.ids)
+        if duplicates != 0:
+            raise RuntimeError(f"Duplicate IDs found ({duplicates} rows)")
+
+
+def pop_keys_from_dict(dictionary, keys):
+    new_dict = {}
+    for key in keys:
+        if key in dictionary:
+            new_dict[key] = dictionary.pop(key)
+    return new_dict
+
+
+class AppointmentStatus(enum.IntEnum):
+    BOOKED = 0
+    ARRIVED = 1
+    DID_NOT_ATTEND = 2
+    IN_PROGRESS = 3
+    FINISHED = 4
+    REQUESTED = 5
+    BLOCKED = 6
+    VISIT = 8
+    WAITING = 9
+    CANCELLED_BY_PATIENT = 10
+    CANCELLED_BY_UNIT = 11
+    CANCELLED_BY_OTHER_SERVICE = 12
+    NO_ACCESS_VISIT = 14
+    CANCELLED_DUE_TO_DEATH = 15
+    PATIENT_WALKED_OUT = 16

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -296,11 +296,11 @@ class ACMEBackend:
             SELECT
               Patient_ID AS patient_id,
               CASE WHEN
-                 dateadd(year, datediff (year, DateOfBirth, {quoted_date}), DateOfBirth) > {quoted_date}
+                 date_add('year', date_diff('year', DateOfBirth, {quoted_date}), DateOfBirth) > {quoted_date}
               THEN
-                 datediff(year, DateOfBirth, {quoted_date}) - 1
+                 date_diff('year', DateOfBirth, {quoted_date}) - 1
               ELSE
-                 datediff(year, DateOfBirth, {quoted_date})
+                 date_diff('year', DateOfBirth, {quoted_date})
               END AS age
             FROM Patient
             """,
@@ -448,11 +448,11 @@ class ACMEBackend:
           END AS date
         FROM ({patients_cte}) AS patients
         LEFT JOIN ({weights_cte}) AS weights
-        ON weights.Patient_ID = patients.Patient_ID AND DATEDIFF(YEAR, patients.DateOfBirth, weights.ConsultationDate) >= {min_age}
+        ON weights.Patient_ID = patients.Patient_ID AND date_diff('year', patients.DateOfBirth, weights.ConsultationDate) >= {min_age}
         LEFT JOIN ({heights_cte}) AS heights
-        ON heights.Patient_ID = patients.Patient_ID AND DATEDIFF(YEAR, patients.DateOfBirth, heights.ConsultationDate) >= {min_age}
+        ON heights.Patient_ID = patients.Patient_ID AND date_diff('year', patients.DateOfBirth, heights.ConsultationDate) >= {min_age}
         LEFT JOIN ({bmi_cte}) AS bmis
-        ON bmis.Patient_ID = patients.Patient_ID AND DATEDIFF(YEAR, patients.DateOfBirth, bmis.ConsultationDate) >= {min_age}
+        ON bmis.Patient_ID = patients.Patient_ID AND date_diff('year', patients.DateOfBirth, bmis.ConsultationDate) >= {min_age}
         -- XXX maybe add a "WHERE NULL..." here
         """
         columns = ["patient_id", "BMI"]
@@ -731,8 +731,8 @@ class ACMEBackend:
               Patient_ID,
               CASE
                 WHEN
-                  DATEDIFF(
-                    day,
+                  date_diff(
+                    'day',
                     LAG(ConsultationDate) OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate),
                     ConsultationDate
                   ) <= {washout_period}
@@ -783,8 +783,8 @@ class ACMEBackend:
               Patient_ID,
               CASE
                 WHEN
-                  DATEDIFF(
-                    day,
+                  date_diff(
+                    'day',
                     LAG(ConsultationDate) OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate),
                     ConsultationDate
                   ) <= {washout_period}

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -157,7 +157,7 @@ class ACMEBackend:
             else:
                 date_format_args = pop_keys_from_dict(query_args, ["date_format"])
                 cols, sql = self.get_query(name, query_type, query_args)
-                table_queries[name] = f"SELECT * INTO _{name} FROM ({sql}) t"
+                table_queries[name] = f"CREATE TABLE _{name} AS {sql}"
                 # The first column should always be patient_id so we can join on it
                 assert cols[0] == "patient_id"
                 output_columns[name] = self.get_column_expression(
@@ -230,7 +230,7 @@ class ACMEBackend:
         output_table = self.get_output_table_name(os.environ.get("TEMP_DATABASE_NAME"))
         if output_table:
             self.log(f"Running final query and writing output to '{output_table}'")
-            sql = f"SELECT * INTO {output_table} FROM ({final_query}) t"
+            sql = f"CREATE TABLE {output_table} AS {final_query}"
             cursor.execute(sql)
             self.log(f"Downloading data from '{output_table}'")
             cursor.execute(f"SELECT * FROM {output_table}")

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -194,7 +194,7 @@ class ACMEBackend:
         column_expr = f"_{source}.{returning}"
         if column_type == "date":
             column_expr = truncate_date(column_expr, date_format)
-        return f"ISNULL({column_expr}, {quote(default_value)})"
+        return f"COALESCE({column_expr}, {quote(default_value)})"
 
     def get_default_value_for_type(self, column_type):
         if column_type == "date":
@@ -900,7 +900,7 @@ class ACMEBackend:
         # These are the columns to which the categorisation expression is
         # allowed to refer
         allowed_columns = {
-            "IsPotentialCareHome": "ISNULL(PotentialCareHomeAddressID, 0)",
+            "IsPotentialCareHome": "COALESCE(PotentialCareHomeAddressID, 0)",
             "LocationRequiresNursing": "LocationRequiresNursing",
             "LocationDoesNotRequireNursing": "LocationDoesNotRequireNursing",
         }

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -433,16 +433,13 @@ class ACMEBackend:
         """
         All patients registered with the same practice through the given period
         """
-        # Note that current registrations are recorded with an EndDate
-        # of 9999-12-31
         return (
             ["patient_id", "is_registered"],
             f"""
             SELECT DISTINCT patient.id AS patient_id, 1 AS is_registered
             FROM patient
-            INNER JOIN RegistrationHistory
-            ON RegistrationHistory."registration-id" = patient.id
-            WHERE StartDate <= {quote(start_date)} AND EndDate > {quote(end_date)}
+            WHERE "registered-date" <= {quote(start_date)}
+              AND ("registration-end-date" > {quote(end_date)} OR "registration-end-date" IS NULL)
             """,
         )
 

--- a/datalab_cohorts/presto_utils.py
+++ b/datalab_cohorts/presto_utils.py
@@ -92,6 +92,8 @@ class CursorProxy:
       not later when you fetch the results)
     * the .description attribute is set immediately after calling .execute()
     * you can iterate over it to yield rows
+    * .fetchone()/.fetchmany()/.fetchall() are disabled (they are not currently
+      used by ACMEBackend, although they could be implemented if required)
     """
 
     _rows = None
@@ -122,3 +124,12 @@ class CursorProxy:
         while self._rows:
             yield from iter(self._rows)
             self._rows = self.cursor.fetchmany()
+
+    def fetchone(self):
+        raise RuntimeError("Iterate over cursor to get results")
+
+    def fetchmany(self, size=None):
+        raise RuntimeError("Iterate over cursor to get results")
+
+    def fetchall(self):
+        raise RuntimeError("Iterate over cursor to get results")

--- a/datalab_cohorts/presto_utils.py
+++ b/datalab_cohorts/presto_utils.py
@@ -67,13 +67,6 @@ def wait_for_presto_to_be_ready(url, timeout):
 
 class ConnectionProxy:
     """Proxy for prestodb.dbapi.Connection, with a more useful cursor.
-
-    Specifically:
-
-    * if prestodb.dpapi.Cursor().execute() triggers an exception, the exception
-      is not raised until you later fetch the results
-    * prestodb.dbapi.Cursor().description is None until you fetch the results
-    * you cannot iterate over a prestodb.dbapi.Cursor
     """
 
     def __init__(self, connection):
@@ -93,7 +86,12 @@ class ConnectionProxy:
 class CursorProxy:
     """Proxy for prestodb.dbapi.Cursor.
 
-    See ConnectionProxy for details.
+    Unlike prestodb.dbapi.Cursor:
+
+    * any exceptions caused by an invalid query are raised by .execute() (and
+      not later when you fetch the results)
+    * the .description attribute is set immediately after calling .execute()
+    * you can iterate over it to yield rows
     """
 
     _rows = None

--- a/datalab_cohorts/presto_utils.py
+++ b/datalab_cohorts/presto_utils.py
@@ -98,8 +98,16 @@ class CursorProxy:
 
     _rows = None
 
-    def __init__(self, cursor):
+    def __init__(self, cursor, batch_size=10 ** 6):
+        """Initialise proxy.
+
+        cursor: the presto.dbapi.Cursor to be proxied
+        batch_size: the number of records to fetch at a time (this will need to
+            be tuned)
+        """
+
         self.cursor = cursor
+        self.batch_size = batch_size
 
     def __getattr__(self, attr):
         """Pass any unhandled attribute lookups to proxied cursor."""
@@ -123,7 +131,7 @@ class CursorProxy:
 
         while self._rows:
             yield from iter(self._rows)
-            self._rows = self.cursor.fetchmany()
+            self._rows = self.cursor.fetchmany(self.batch_size)
 
     def fetchone(self):
         raise RuntimeError("Iterate over cursor to get results")

--- a/datalab_cohorts/study_definition.py
+++ b/datalab_cohorts/study_definition.py
@@ -77,6 +77,10 @@ class StudyDefinition:
             from .tpp_backend import TPPBackend
 
             return TPPBackend
+        elif database_url.startswith("presto://"):
+            from .acme_backend import ACMEBackend
+
+            return ACMEBackend
         else:
             raise ValueError(f"No matching backend found for {database_url}")
 

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -89,7 +89,7 @@ medication_issue = Table(
     Column("StartDate", DateTime),
     Column("EndDate", DateTime),
     Column("MedicationStatus", String),
-    Column("ConsultationDate", DateTime),
+    Column("effective-date", DateTime),
 )
 
 # WARNING: This table does not correspond to a table in the ACME database!
@@ -115,7 +115,7 @@ coded_event = Table(
     Column("CodedEvent_ID", Integer, primary_key=True),
     Column("CTV3Code", String(collation="Latin1_General_BIN")),
     Column("NumericValue", Float),
-    Column("ConsultationDate", DateTime),
+    Column("effective-date", DateTime),
     Column("SnomedConceptId", String),
 )
 
@@ -250,6 +250,7 @@ class Model:
         for k, v in kwargs.items():
             if k in [
                 "date_of_birth",
+                "effective_date",
             ]:
                 k = k.replace("_", "-")
             setattr(self, k, v)

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -1,0 +1,401 @@
+"""
+The ACME data is accessed via Presto which is a distributed query engine which
+runs over multiple backing data stores ("connectors" in Presto's parlance).
+The production configuration uses the following connectors:
+
+    hive for views
+    delta-lake for underlying data
+    mysql for config/metadata
+
+For immediate convenience while testing we use the SQL Server connector (as we
+already need an instance running for the TPP tests).
+"""
+import os
+import time
+
+import sqlalchemy
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, DateTime, Float, NVARCHAR, Date
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import relationship
+
+from datalab_cohorts.mssql_utils import mssql_sqlalchemy_engine_from_url
+from datalab_cohorts.presto_utils import wait_for_presto_to_be_ready
+
+
+Base = declarative_base()
+
+
+def make_engine():
+    engine = mssql_sqlalchemy_engine_from_url(
+        os.environ["ACME_DATASOURCE_DATABASE_URL"]
+    )
+    timeout = os.environ.get("CONNECTION_RETRY_TIMEOUT")
+    timeout = float(timeout) if timeout else 60
+    # Wait for the database to be ready if it isn't already
+    start = time.time()
+    while True:
+        try:
+            engine.connect()
+            break
+        except sqlalchemy.exc.DBAPIError:
+            if time.time() - start < timeout:
+                time.sleep(1)
+            else:
+                raise
+    wait_for_presto_to_be_ready(os.environ["ACME_DATABASE_URL"], timeout)
+    return engine
+
+
+def make_session():
+    engine = make_engine()
+    Session = sessionmaker()
+    Session.configure(bind=engine)
+    session = Session()
+    return session
+
+
+def make_database():
+    Base.metadata.create_all(make_engine())
+
+
+class MedicationIssue(Base):
+    __tablename__ = "MedicationIssue"
+
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship("Patient", back_populates="MedicationIssues")
+    Consultation_ID = Column(Integer)
+    MedicationIssue_ID = Column(Integer, primary_key=True)
+    RepeatMedication_ID = Column(Integer)
+    MultilexDrug_ID = Column(
+        NVARCHAR(length=20), ForeignKey("MedicationDictionary.MultilexDrug_ID")
+    )
+    MedicationDictionary = relationship(
+        "MedicationDictionary", back_populates="MedicationIssues", cascade="all, delete"
+    )
+    Dose = Column(String)
+    Quantity = Column(String)
+    StartDate = Column(DateTime)
+    EndDate = Column(DateTime)
+    MedicationStatus = Column(String)
+    ConsultationDate = Column(DateTime)
+
+
+class MedicationDictionary(Base):
+    __tablename__ = "MedicationDictionary"
+
+    MultilexDrug_ID = Column(NVARCHAR(length=20), primary_key=True)
+    MedicationIssues = relationship(
+        "MedicationIssue", back_populates="MedicationDictionary"
+    )
+    ProductId = Column(String)
+    FullName = Column(String)
+    RootName = Column(String)
+    PackDescription = Column(String)
+    Form = Column(String)
+    Strength = Column(String)
+    CompanyName = Column(String)
+    DMD_ID = Column(String(collation="Latin1_General_CI_AS"))
+
+
+class CodedEvent(Base):
+    __tablename__ = "CodedEvent"
+
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="CodedEvents", cascade="all, delete"
+    )
+    CodedEvent_ID = Column(Integer, primary_key=True)
+    CTV3Code = Column(String(collation="Latin1_General_BIN"))
+    NumericValue = Column(Float)
+    ConsultationDate = Column(DateTime)
+    SnomedConceptId = Column(String)
+
+
+class Appointment(Base):
+    __tablename__ = "Appointment"
+
+    Appointment_ID = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="Appointments", cascade="all, delete"
+    )
+    Organisation_ID = Column(Integer, ForeignKey("Organisation.Organisation_ID"))
+    Organisation = relationship(
+        "Organisation", back_populates="Appointments", cascade="all, delete"
+    )
+    # The real table has various other datetime columns but we don't currently
+    # use them
+    SeenDate = Column(DateTime)
+    Status = Column(Integer)
+
+
+class Patient(Base):
+    __tablename__ = "Patient"
+
+    Patient_ID = Column(Integer, primary_key=True)
+    DateOfBirth = Column(Date)
+    DateOfDeath = Column(Date)
+
+    Appointments = relationship(
+        "Appointment", back_populates="Patient", cascade="all, delete, delete-orphan",
+    )
+    MedicationIssues = relationship(
+        "MedicationIssue",
+        back_populates="Patient",
+        cascade="all, delete, delete-orphan",
+    )
+    CodedEvents = relationship(
+        "CodedEvent", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    ICNARC = relationship(
+        "ICNARC", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    ONSDeath = relationship(
+        "ONSDeaths", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    CPNS = relationship(
+        "CPNS", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    RegistrationHistory = relationship(
+        "RegistrationHistory",
+        back_populates="Patient",
+        cascade="all, delete, delete-orphan",
+    )
+    Addresses = relationship(
+        "PatientAddress", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    Vaccinations = relationship(
+        "Vaccination", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    SGSS_Positives = relationship(
+        "SGSS_Positive", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    SGSS_Negatives = relationship(
+        "SGSS_Negative", back_populates="Patient", cascade="all, delete, delete-orphan"
+    )
+    Sex = Column(String)
+
+
+class RegistrationHistory(Base):
+    __tablename__ = "RegistrationHistory"
+
+    Registration_ID = Column(Integer, primary_key=True)
+    Organisation_ID = Column(Integer, ForeignKey("Organisation.Organisation_ID"))
+    Organisation = relationship(
+        "Organisation", back_populates="RegistrationHistory", cascade="all, delete"
+    )
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="RegistrationHistory", cascade="all, delete"
+    )
+    StartDate = Column(Date)
+    EndDate = Column(Date)
+
+
+class Organisation(Base):
+    __tablename__ = "Organisation"
+
+    Organisation_ID = Column(Integer, primary_key=True)
+    GoLiveDate = Column(Date)
+    STPCode = Column(String)
+    MSOACode = Column(String)
+    RegistrationHistory = relationship(
+        "RegistrationHistory",
+        back_populates="Organisation",
+        cascade="all, delete, delete-orphan",
+    )
+    Region = Column(String)
+    Appointments = relationship(
+        "Appointment",
+        back_populates="Organisation",
+        cascade="all, delete, delete-orphan",
+    )
+
+
+class PatientAddress(Base):
+    __tablename__ = "PatientAddress"
+
+    PatientAddress_ID = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship("Patient", back_populates="Addresses", cascade="all, delete")
+    StartDate = Column(Date)
+    EndDate = Column(Date)
+    AddressType = Column(Integer)
+    RuralUrbanClassificationCode = Column(Integer)
+    ImdRankRounded = Column(Integer)
+    MSOACode = Column(String)
+    PotentialCareHomeAddress = relationship(
+        "PotentialCareHomeAddress",
+        back_populates="PatientAddress",
+        cascade="all, delete, delete-orphan",
+    )
+
+
+class ICNARC(Base):
+    __tablename__ = "ICNARC"
+
+    ICNARC_ID = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship("Patient", back_populates="ICNARC", cascade="all, delete")
+    IcuAdmissionDateTime = Column(DateTime)
+    OriginalIcuAdmissionDate = Column(Date)
+    BasicDays_RespiratorySupport = Column(Integer)
+    AdvancedDays_RespiratorySupport = Column(Integer)
+    Ventilator = Column(Integer)
+
+
+class ONSDeaths(Base):
+    __tablename__ = "ONS_Deaths"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship("Patient", back_populates="ONSDeath", cascade="all, delete")
+    Sex = Column(String)
+    ageinyrs = Column(Integer)
+    dod = Column(Date)
+    icd10u = Column(String)
+    ICD10001 = Column(String)
+    ICD10002 = Column(String)
+    ICD10003 = Column(String)
+    ICD10004 = Column(String)
+    ICD10005 = Column(String)
+    ICD10006 = Column(String)
+    ICD10007 = Column(String)
+    ICD10008 = Column(String)
+    ICD10009 = Column(String)
+    ICD10010 = Column(String)
+    ICD10011 = Column(String)
+    ICD10012 = Column(String)
+    ICD10013 = Column(String)
+    ICD10014 = Column(String)
+    ICD10015 = Column(String)
+
+
+class CPNS(Base):
+    __tablename__ = "CPNS"
+
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship("Patient", back_populates="CPNS", cascade="all, delete")
+    Id = Column(Integer, primary_key=True)
+    # LocationOfDeath                                                 ITU
+    # Sex                                                               M
+    # DateOfAdmission                                          2020-04-02
+    # DateOfSwabbed                                            2020-04-02
+    # DateOfResult                                             2020-04-03
+    # RelativesAware                                                    Y
+    # TravelHistory                                                 False
+    # RegionCode                                                      Y62
+    # RegionName                                               North West
+    # OrganisationCode                                                ABC
+    # OrganisationName                                Test Hospital Trust
+    # OrganisationTypeLot                                        Hospital
+    # RegionApproved                                                 True
+    # RegionalApprovedDate                                     2020-04-09
+    # NationalApproved                                               True
+    # NationalApprovedDate                                     2020-04-09
+    # PreExistingCondition                                          False
+    # Age                                                              57
+    DateOfDeath = Column(Date)
+    # snapDate                                                 2020-04-09
+    # HadLearningDisability                                            NK
+    # ReceivedTreatmentForMentalHealth                                 NK
+    # Der_Ethnic_Category_Description                                None
+    # Der_Latest_SUS_Attendance_Date_For_Ethnicity                   None
+    # Der_Source_Dataset_For_Ethnicty                                None
+
+
+class Vaccination(Base):
+    __tablename__ = "Vaccination"
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="Vaccinations", cascade="all, delete"
+    )
+    Vaccination_ID = Column(Integer, primary_key=True)
+    VaccinationDate = Column(DateTime)
+    VaccinationName = Column(String)
+    # We can't make this a foreign key because the corresponding column isn't
+    # unique.  Effectively, there's an implied but not existing VaccinationName
+    # table which has a many-one relation with Vaccination and a one-many
+    # relation with VaccinationReference.
+    VaccinationName_ID = Column(Integer)
+    VaccinationSchedulePart = Column(Integer)
+
+
+class VaccinationReference(Base):
+    __tablename__ = "VaccinationReference"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+    # Note this is *not* unique because a single named vaccine product can
+    # target multiple diseases and therefore have multiple "contents"
+    VaccinationName_ID = Column(Integer)
+    VaccinationName = Column(String)
+    VaccinationContent = Column(String)
+
+
+class SGSS_Negative(Base):
+    __tablename__ = "SGSS_Negative"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="SGSS_Negatives", cascade="all, delete"
+    )
+    Organism_Species_Name = Column(String, default="NEGATIVE SARS-CoV-2 (COVID-19)")
+    Earliest_Specimen_Date = Column(Date)
+    Lab_Report_Date = Column(Date)
+    # Other columns in the table which we don't use:
+    #   PHE_ID
+    #   Age_in_Years
+    #   Patient_Sex
+    #   County_Description
+    #   PostCode_Source
+
+
+class SGSS_Positive(Base):
+    __tablename__ = "SGSS_Positive"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    Patient = relationship(
+        "Patient", back_populates="SGSS_Positives", cascade="all, delete"
+    )
+    Organism_Species_Name = Column(String, default="SARS-CoV-2 CORONAVIRUS (Covid-19)")
+    Earliest_Specimen_Date = Column(Date)
+    Lab_Report_Date = Column(Date)
+    # Other columns in the table which we don't use:
+    #   PHE_ID
+    #   Age_in_Years
+    #   Patient_Sex
+    #   County_Description
+    #   PostCode_Source
+
+
+class PotentialCareHomeAddress(Base):
+    __tablename__ = "PotentialCareHomeAddress"
+
+    # This column isn't in the actual database but SQLAlchemy gets a bit upset
+    # if we don't give it a primary key
+    id = Column(Integer, primary_key=True)
+
+    Patient_ID = Column(Integer, ForeignKey("Patient.Patient_ID"))
+    PatientAddress_ID = Column(Integer, ForeignKey("PatientAddress.PatientAddress_ID"))
+    PatientAddress = relationship(
+        "PatientAddress",
+        back_populates="PotentialCareHomeAddress",
+        cascade="all, delete",
+    )
+    # Conceptually these two are a single boolean column but they stored as
+    # separate string columns containing either a Y or an N as this directly
+    # reflects what's in the underlying data source
+    LocationRequiresNursing = Column(String)
+    LocationDoesNotRequireNursing = Column(String)

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -107,16 +107,15 @@ medication_dictionary = Table(
     Column("DMD_ID", String(collation="Latin1_General_CI_AS")),
 )
 
-# WARNING: This table does not correspond to a table in the ACME database!
-coded_event = Table(
-    "CodedEvent",
+# WARNING: This table does not quite correspond to a table in the ACME database!
+observation = Table(
+    "observation",
     metadata,
+    Column("id", Integer, primary_key=True),
     Column("registration-id", Integer, ForeignKey("patient.id")),
-    Column("CodedEvent_ID", Integer, primary_key=True),
-    Column("CTV3Code", String(collation="Latin1_General_BIN")),
-    Column("NumericValue", Float),
+    Column("snomed-concept-id", String),  # TODO this is a BigInt in the ACME backend
+    Column("value-pq-1", Float),
     Column("effective-date", DateTime),
-    Column("SnomedConceptId", String),
 )
 
 patient = Table(
@@ -251,6 +250,8 @@ class Model:
             if k in [
                 "date_of_birth",
                 "effective_date",
+                "snomed_concept_id",
+                "value_pq_1",
             ]:
                 k = k.replace("_", "-")
             setattr(self, k, v)
@@ -260,7 +261,7 @@ class MedicationIssue(Model):
     pass
 
 
-class CodedEvent(Model):
+class Observation(Model):
     pass
 
 
@@ -314,9 +315,9 @@ mapper(
 )
 
 mapper(
-    CodedEvent,
-    coded_event,
-    properties={"patient": relationship(Patient, back_populates="CodedEvents"),},
+    Observation,
+    observation,
+    properties={"patient": relationship(Patient, back_populates="observations"),},
 )
 
 mapper(
@@ -338,8 +339,8 @@ mapper(
             back_populates="patient",
             cascade="all, delete, delete-orphan",
         ),
-        "CodedEvents": relationship(
-            CodedEvent, back_populates="patient", cascade="all, delete, delete-orphan"
+        "observations": relationship(
+            Observation, back_populates="patient", cascade="all, delete, delete-orphan"
         ),
         "RegistrationHistory": relationship(
             RegistrationHistory,

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -98,17 +98,8 @@ patient = Table(
     Column("id", Integer, primary_key=True),
     Column("date-of-birth", DateTime),
     Column("gender", Integer),
-)
-
-# WARNING: This table does not correspond to a table in the ACME database!
-registration_history = Table(
-    "RegistrationHistory",
-    metadata,
-    Column("Registration_ID", Integer, primary_key=True),
-    Column("Organisation_ID", Integer, ForeignKey("Organisation.Organisation_ID")),
-    Column("registration-id", Integer, ForeignKey("patient.id")),
-    Column("StartDate", Date),
-    Column("EndDate", Date),
+    Column("registered-date", DateTime),
+    Column("registration-end-date", DateTime),
 )
 
 # WARNING: This table does not correspond to a table in the ACME database!
@@ -224,6 +215,8 @@ class Model:
             if k in [
                 "date_of_birth",
                 "effective_date",
+                "registered_date",
+                "registration_end_date",
                 "snomed_concept_id",
                 "value_pq_1",
             ]:
@@ -240,10 +233,6 @@ class Observation(Model):
 
 
 class Patient(Model):
-    pass
-
-
-class RegistrationHistory(Model):
     pass
 
 
@@ -293,11 +282,6 @@ mapper(
         "observations": relationship(
             Observation, back_populates="patient", cascade="all, delete, delete-orphan"
         ),
-        "RegistrationHistory": relationship(
-            RegistrationHistory,
-            back_populates="patient",
-            cascade="all, delete, delete-orphan",
-        ),
         #
         # We won't create mappings for these tables until we know what fields
         # they will have in the ACME backend.
@@ -321,29 +305,10 @@ mapper(
 
 # We won't create mappings for these tables until we know what fields they will
 # have in the ACME backend.
-# mapper(
-#     RegistrationHistory,
-#     registration_history,
-#     properties={
-#         "Organisation": relationship(
-#             Organisation, back_populates="RegistrationHistory", cascade="all, delete"
-#         ),
-#         "Patient": relationship(
-#             Patient, back_populates="RegistrationHistory", cascade="all, delete"
-#         ),
-#     },
-# )
 
 # mapper(
 #     Organisation,
 #     organisation,
-#     properties={
-#         "RegistrationHistory": relationship(
-#             RegistrationHistory,
-#             back_populates="Organisation",
-#             cascade="all, delete, delete-orphan",
-#         )
-#     },
 # )
 
 # mapper(

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -71,40 +71,14 @@ def make_database():
 # Table definitions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# WARNING: This table does not correspond to a table in the ACME database!
-medication_issue = Table(
-    "MedicationIssue",
+# WARNING: This table does not quite correspond to a table in the ACME database!
+medication = Table(
+    "medication",
     metadata,
+    Column("id", Integer, primary_key=True),
     Column("registration-id", Integer, ForeignKey("patient.id")),
-    Column("Consultation_ID", Integer),
-    Column("MedicationIssue_ID", Integer, primary_key=True),
-    Column("RepeatMedication_ID", Integer),
-    Column(
-        "MultilexDrug_ID",
-        NVARCHAR(length=20),
-        ForeignKey("MedicationDictionary.MultilexDrug_ID"),
-    ),
-    Column("Dose", String),
-    Column("Quantity", String),
-    Column("StartDate", DateTime),
-    Column("EndDate", DateTime),
-    Column("MedicationStatus", String),
+    Column("snomed-concept-id", String),  # TODO this is a BigInt in the ACME backend
     Column("effective-date", DateTime),
-)
-
-# WARNING: This table does not correspond to a table in the ACME database!
-medication_dictionary = Table(
-    "MedicationDictionary",
-    metadata,
-    Column("MultilexDrug_ID", NVARCHAR(length=20), primary_key=True),
-    Column("ProductId", String),
-    Column("FullName", String),
-    Column("RootName", String),
-    Column("PackDescription", String),
-    Column("Form", String),
-    Column("Strength", String),
-    Column("CompanyName", String),
-    Column("DMD_ID", String(collation="Latin1_General_CI_AS")),
 )
 
 # WARNING: This table does not quite correspond to a table in the ACME database!
@@ -257,15 +231,11 @@ class Model:
             setattr(self, k, v)
 
 
-class MedicationIssue(Model):
+class Medication(Model):
     pass
 
 
 class Observation(Model):
-    pass
-
-
-class MedicationDictionary(Model):
     pass
 
 
@@ -302,16 +272,9 @@ class CPNS(Model):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 mapper(
-    MedicationIssue,
-    medication_issue,
-    properties={
-        "patient": relationship(Patient, back_populates="MedicationIssues"),
-        "MedicationDictionary": relationship(
-            MedicationDictionary,
-            back_populates="MedicationIssues",
-            cascade="all, delete",
-        ),
-    },
+    Medication,
+    medication,
+    properties={"patient": relationship(Patient, back_populates="medications"),},
 )
 
 mapper(
@@ -321,23 +284,11 @@ mapper(
 )
 
 mapper(
-    MedicationDictionary,
-    medication_dictionary,
-    properties={
-        "MedicationIssues": relationship(
-            MedicationIssue, back_populates="MedicationDictionary"
-        )
-    },
-)
-
-mapper(
     Patient,
     patient,
     properties={
-        "MedicationIssues": relationship(
-            MedicationIssue,
-            back_populates="patient",
-            cascade="all, delete, delete-orphan",
+        "medications": relationship(
+            Medication, back_populates="patient", cascade="all, delete, delete-orphan",
         ),
         "observations": relationship(
             Observation, back_populates="patient", cascade="all, delete, delete-orphan"

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -60,6 +60,7 @@ def make_database():
     Base.metadata.create_all(make_engine())
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class MedicationIssue(Base):
     __tablename__ = "MedicationIssue"
 
@@ -82,6 +83,7 @@ class MedicationIssue(Base):
     ConsultationDate = Column(DateTime)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class MedicationDictionary(Base):
     __tablename__ = "MedicationDictionary"
 
@@ -99,6 +101,7 @@ class MedicationDictionary(Base):
     DMD_ID = Column(String(collation="Latin1_General_CI_AS"))
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class CodedEvent(Base):
     __tablename__ = "CodedEvent"
 
@@ -113,6 +116,7 @@ class CodedEvent(Base):
     SnomedConceptId = Column(String)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class Patient(Base):
     __tablename__ = "Patient"
 
@@ -148,6 +152,7 @@ class Patient(Base):
     Sex = Column(String)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class RegistrationHistory(Base):
     __tablename__ = "RegistrationHistory"
 
@@ -164,6 +169,7 @@ class RegistrationHistory(Base):
     EndDate = Column(Date)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class Organisation(Base):
     __tablename__ = "Organisation"
 
@@ -179,6 +185,7 @@ class Organisation(Base):
     Region = Column(String)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class PatientAddress(Base):
     __tablename__ = "PatientAddress"
 
@@ -193,6 +200,7 @@ class PatientAddress(Base):
     MSOACode = Column(String)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class ICNARC(Base):
     __tablename__ = "ICNARC"
 
@@ -206,6 +214,7 @@ class ICNARC(Base):
     Ventilator = Column(Integer)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class ONSDeaths(Base):
     __tablename__ = "ONS_Deaths"
 
@@ -235,6 +244,7 @@ class ONSDeaths(Base):
     ICD10015 = Column(String)
 
 
+# WARNING: This table does not correspond to a table in the ACME database!
 class CPNS(Base):
     __tablename__ = "CPNS"
 

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -338,85 +338,91 @@ mapper(
         "CodedEvents": relationship(
             CodedEvent, back_populates="Patient", cascade="all, delete, delete-orphan"
         ),
-        "ICNARC": relationship(
-            ICNARC, back_populates="Patient", cascade="all, delete, delete-orphan"
-        ),
-        "ONSDeath": relationship(
-            ONSDeaths, back_populates="Patient", cascade="all, delete, delete-orphan"
-        ),
-        "CPNS": relationship(
-            CPNS, back_populates="Patient", cascade="all, delete, delete-orphan"
-        ),
         "RegistrationHistory": relationship(
             RegistrationHistory,
             back_populates="Patient",
             cascade="all, delete, delete-orphan",
         ),
-        "Addresses": relationship(
-            PatientAddress,
-            back_populates="Patient",
-            cascade="all, delete, delete-orphan",
-        ),
+        #
+        # We won't create mappings for these tables until we know what fields
+        # they will have in the ACME backend.
+        #
+        # "Addresses": relationship(
+        #     PatientAddress,
+        #     back_populates="patient",
+        #     cascade="all, delete, delete-orphan",
+        # ),
+        # "ICNARC": relationship(
+        #     ICNARC, back_populates="Patient", cascade="all, delete, delete-orphan"
+        # ),
+        # "ONSDeath": relationship(
+        #     ONSDeaths, back_populates="Patient", cascade="all, delete, delete-orphan"
+        # ),
+        # "CPNS": relationship(
+        #     CPNS, back_populates="Patient", cascade="all, delete, delete-orphan"
+        # ),
     },
 )
 
-mapper(
-    RegistrationHistory,
-    registration_history,
-    properties={
-        "Organisation": relationship(
-            Organisation, back_populates="RegistrationHistory", cascade="all, delete"
-        ),
-        "Patient": relationship(
-            Patient, back_populates="RegistrationHistory", cascade="all, delete"
-        ),
-    },
-)
+# We won't create mappings for these tables until we know what fields they will
+# have in the ACME backend.
+# mapper(
+#     RegistrationHistory,
+#     registration_history,
+#     properties={
+#         "Organisation": relationship(
+#             Organisation, back_populates="RegistrationHistory", cascade="all, delete"
+#         ),
+#         "Patient": relationship(
+#             Patient, back_populates="RegistrationHistory", cascade="all, delete"
+#         ),
+#     },
+# )
 
-mapper(
-    Organisation,
-    organisation,
-    properties={
-        "RegistrationHistory": relationship(
-            RegistrationHistory,
-            back_populates="Organisation",
-            cascade="all, delete, delete-orphan",
-        )
-    },
-)
+# mapper(
+#     Organisation,
+#     organisation,
+#     properties={
+#         "RegistrationHistory": relationship(
+#             RegistrationHistory,
+#             back_populates="Organisation",
+#             cascade="all, delete, delete-orphan",
+#         )
+#     },
+# )
 
-mapper(
-    PatientAddress,
-    patient_address,
-    properties={
-        "Patient": relationship(
-            Patient, back_populates="Addresses", cascade="all, delete"
-        )
-    },
-)
+# mapper(
+#     PatientAddress,
+#     patient_address,
+#     properties={
+#         "patient": relationship(
+#             Patient, back_populates="Addresses", cascade="all, delete"
+#         )
+#     },
+# )
 
-mapper(
-    ICNARC,
-    icnarc,
-    properties={
-        "Patient": relationship(Patient, back_populates="ICNARC", cascade="all, delete")
-    },
-)
+# mapper(
+#     ICNARC,
+#     icnarc,
+#     properties={
+#         "Patient": relationship(Patient, back_populates="ICNARC", cascade="all, delete")
+#     },
+# )
 
-mapper(
-    ONSDeaths,
-    ons_deaths,
-    properties={
-        "Patient": relationship(
-            Patient, back_populates="ONSDeath", cascade="all, delete"
-        )
-    },
-)
+# mapper(
+#     ONSDeaths,
+#     ons_deaths,
+#     properties={
+#         "Patient": relationship(
+#             Patient, back_populates="ONSDeath", cascade="all, delete"
+#         )
+#     },
+# )
 
-mapper(
-    CPNS,
-    cpns,
-    properties={
-        "Patient": relationship(Patient, back_populates="CPNS", cascade="all, delete")
-    },
-)
+# mapper(
+#     CPNS,
+#     cpns,
+#     properties={
+#         "Patient": relationship(Patient, back_populates="CPNS", cascade="all, delete")
+#     },
+# )

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -75,7 +75,7 @@ def make_database():
 medication_issue = Table(
     "MedicationIssue",
     metadata,
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("Consultation_ID", Integer),
     Column("MedicationIssue_ID", Integer, primary_key=True),
     Column("RepeatMedication_ID", Integer),
@@ -111,7 +111,7 @@ medication_dictionary = Table(
 coded_event = Table(
     "CodedEvent",
     metadata,
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("CodedEvent_ID", Integer, primary_key=True),
     Column("CTV3Code", String(collation="Latin1_General_BIN")),
     Column("NumericValue", Float),
@@ -123,7 +123,7 @@ coded_event = Table(
 patient = Table(
     "Patient",
     metadata,
-    Column("Patient_ID", Integer, primary_key=True),
+    Column("id", Integer, primary_key=True),
     Column("DateOfBirth", Date),
     Column("DateOfDeath", Date),
     Column("Sex", String),
@@ -135,7 +135,7 @@ registration_history = Table(
     metadata,
     Column("Registration_ID", Integer, primary_key=True),
     Column("Organisation_ID", Integer, ForeignKey("Organisation.Organisation_ID")),
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("StartDate", Date),
     Column("EndDate", Date),
 )
@@ -156,7 +156,7 @@ patient_address = Table(
     "PatientAddress",
     metadata,
     Column("PatientAddress_ID", Integer, primary_key=True),
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("StartDate", Date),
     Column("EndDate", Date),
     Column("AddressType", Integer),
@@ -170,7 +170,7 @@ icnarc = Table(
     "ICNARC",
     metadata,
     Column("ICNARC_ID", Integer, primary_key=True),
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("IcuAdmissionDateTime", DateTime),
     Column("OriginalIcuAdmissionDate", Date),
     Column("BasicDays_RespiratorySupport", Integer),
@@ -185,7 +185,7 @@ ons_deaths = Table(
     # This column isn't in the actual database but SQLAlchemy gets a bit upset
     # if we don't give it a primary key
     Column("id", Integer, primary_key=True),
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("Sex", String),
     Column("ageinyrs", Integer),
     Column("dod", Date),
@@ -211,7 +211,7 @@ ons_deaths = Table(
 cpns = Table(
     "CPNS",
     metadata,
-    Column("Patient_ID", Integer, ForeignKey("Patient.Patient_ID")),
+    Column("registration-id", Integer, ForeignKey("Patient.id")),
     Column("Id", Integer, primary_key=True),
     # LocationOfDeath                                                 ITU
     # Sex                                                               M

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -125,16 +125,16 @@ def test_meds_with_count():
     patient_with_med = Patient()
     patient_with_med.MedicationIssues = [
         MedicationIssue(
-            MedicationDictionary=asthma_medication, ConsultationDate="2010-01-01"
+            MedicationDictionary=asthma_medication, effective_date="2010-01-01"
         ),
         MedicationIssue(
-            MedicationDictionary=asthma_medication, ConsultationDate="2015-01-01"
+            MedicationDictionary=asthma_medication, effective_date="2015-01-01"
         ),
         MedicationIssue(
-            MedicationDictionary=asthma_medication, ConsultationDate="2018-01-01"
+            MedicationDictionary=asthma_medication, effective_date="2018-01-01"
         ),
         MedicationIssue(
-            MedicationDictionary=asthma_medication, ConsultationDate="2020-01-01"
+            MedicationDictionary=asthma_medication, effective_date="2020-01-01"
         ),
     ]
     patient_without_med = Patient()
@@ -172,7 +172,7 @@ def _make_clinical_events_selection(condition_code, patient_dates=None):
                 value = 0.0
             patient.CodedEvents.append(
                 CodedEvent(
-                    CTV3Code=condition_code, ConsultationDate=date, NumericValue=value
+                    CTV3Code=condition_code, effective_date=date, NumericValue=value,
                 )
             )
         session.add(patient)
@@ -407,12 +407,12 @@ def test_clinical_event_with_category():
             Patient(),
             Patient(
                 CodedEvents=[
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2018-01-01"),
-                    CodedEvent(CTV3Code="foo2", ConsultationDate="2020-01-01"),
+                    CodedEvent(CTV3Code="foo1", effective_date="2018-01-01"),
+                    CodedEvent(CTV3Code="foo2", effective_date="2020-01-01"),
                 ]
             ),
             Patient(
-                CodedEvents=[CodedEvent(CTV3Code="foo3", ConsultationDate="2019-01-01")]
+                CodedEvents=[CodedEvent(CTV3Code="foo3", effective_date="2019-01-01")]
             ),
         ]
     )
@@ -469,10 +469,10 @@ def test_simple_bmi(include_dates):
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2002-06-01")
+        CodedEvent(CTV3Code=weight_code, NumericValue=50, effective_date="2002-06-01",)
     )
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=height_code, NumericValue=10, ConsultationDate="2001-06-01")
+        CodedEvent(CTV3Code=height_code, NumericValue=10, effective_date="2001-06-01",)
     )
     session.add(patient)
     session.commit()
@@ -510,11 +510,11 @@ def test_bmi_rounded():
     patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(
-            CTV3Code=weight_code, NumericValue=10.12345, ConsultationDate="2001-06-01"
+            CTV3Code=weight_code, NumericValue=10.12345, effective_date="2001-06-01",
         )
     )
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=height_code, NumericValue=10, ConsultationDate="2000-02-01")
+        CodedEvent(CTV3Code=height_code, NumericValue=10, effective_date="2000-02-01",)
     )
     session.add(patient)
     session.commit()
@@ -537,10 +537,10 @@ def test_bmi_with_zero_values():
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=weight_code, NumericValue=0, ConsultationDate="2001-06-01")
+        CodedEvent(CTV3Code=weight_code, NumericValue=0, effective_date="2001-06-01")
     )
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=height_code, NumericValue=0, ConsultationDate="2001-06-01")
+        CodedEvent(CTV3Code=height_code, NumericValue=0, effective_date="2001-06-01")
     )
     session.add(patient)
     session.commit()
@@ -565,10 +565,10 @@ def test_explicit_bmi_fallback():
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2001-06-01")
+        CodedEvent(CTV3Code=weight_code, NumericValue=50, effective_date="2001-06-01",)
     )
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-10-01")
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, effective_date="2001-10-01")
     )
     session.add(patient)
     session.commit()
@@ -592,7 +592,7 @@ def test_no_bmi_when_old_date():
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="1994-12-31")
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, effective_date="1994-12-31")
     )
     session.add(patient)
     session.commit()
@@ -616,7 +616,7 @@ def test_no_bmi_when_measurements_of_child():
 
     patient = Patient(date_of_birth="2000-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-01-01")
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, effective_date="2001-01-01")
     )
     session.add(patient)
     session.commit()
@@ -640,7 +640,7 @@ def test_no_bmi_when_measurement_after_reference_date():
 
     patient = Patient(date_of_birth="1900-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-01-01")
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, effective_date="2001-01-01")
     )
     session.add(patient)
     session.commit()
@@ -666,13 +666,13 @@ def test_bmi_when_only_some_measurements_of_child():
 
     patient = Patient(date_of_birth="1990-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="1995-01-01")
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, effective_date="1995-01-01")
     )
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=weight_code, NumericValue=50, effective_date="2010-01-01",)
     )
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code=height_code, NumericValue=10, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=height_code, NumericValue=10, effective_date="2010-01-01",)
     )
     session.add(patient)
     session.commit()
@@ -702,11 +702,11 @@ def test_mean_recorded_value():
     ]
     for date, value in values:
         patient.CodedEvents.append(
-            CodedEvent(CTV3Code=code, NumericValue=value, ConsultationDate=date)
+            CodedEvent(CTV3Code=code, NumericValue=value, effective_date=date)
         )
     patient_with_old_reading = Patient()
     patient_with_old_reading.CodedEvents.append(
-        CodedEvent(CTV3Code=code, NumericValue=100, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=code, NumericValue=100, effective_date="2010-01-01")
     )
     patient_with_no_reading = Patient()
     session.add_all([patient, patient_with_old_reading, patient_with_no_reading])
@@ -735,7 +735,7 @@ def test_patients_satisfying():
     patient_3 = Patient(date_of_birth="1990-01-01", gender=1)
     patient_4 = Patient(date_of_birth="1940-01-01", gender=2)
     patient_4.CodedEvents.append(
-        CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=condition_code, effective_date="2010-01-01")
     )
     session.add_all([patient_1, patient_2, patient_3, patient_4])
     session.commit()
@@ -761,14 +761,14 @@ def test_patients_satisfying_with_hidden_columns():
     patient_3 = Patient(date_of_birth="1990-01-01", gender=1)
     patient_4 = Patient(date_of_birth="1940-01-01", gender=2)
     patient_4.CodedEvents.append(
-        CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=condition_code, effective_date="2010-01-01")
     )
     patient_5 = Patient(date_of_birth="1940-01-01", gender=2)
     patient_5.CodedEvents.append(
-        CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=condition_code, effective_date="2010-01-01")
     )
     patient_5.CodedEvents.append(
-        CodedEvent(CTV3Code=condition_code2, ConsultationDate="2010-01-01")
+        CodedEvent(CTV3Code=condition_code2, effective_date="2010-01-01")
     )
     session.add_all([patient_1, patient_2, patient_3, patient_4, patient_5])
     session.commit()
@@ -801,34 +801,26 @@ def test_patients_categorised_as():
         [
             Patient(
                 gender=1,
-                CodedEvents=[
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
-                ],
+                CodedEvents=[CodedEvent(CTV3Code="foo1", effective_date="2000-01-01")],
             ),
             Patient(
                 gender=2,
                 CodedEvents=[
-                    CodedEvent(CTV3Code="foo2", ConsultationDate="2000-01-01"),
-                    CodedEvent(CTV3Code="bar1", ConsultationDate="2000-01-01"),
+                    CodedEvent(CTV3Code="foo2", effective_date="2000-01-01"),
+                    CodedEvent(CTV3Code="bar1", effective_date="2000-01-01"),
                 ],
             ),
             Patient(
                 gender=1,
-                CodedEvents=[
-                    CodedEvent(CTV3Code="foo2", ConsultationDate="2000-01-01")
-                ],
+                CodedEvents=[CodedEvent(CTV3Code="foo2", effective_date="2000-01-01")],
             ),
             Patient(
                 gender=2,
-                CodedEvents=[
-                    CodedEvent(CTV3Code="foo3", ConsultationDate="2000-01-01")
-                ],
+                CodedEvents=[CodedEvent(CTV3Code="foo3", effective_date="2000-01-01")],
             ),
             Patient(
                 gender=2,
-                CodedEvents=[
-                    CodedEvent(CTV3Code="bar1", ConsultationDate="2000-01-01"),
-                ],
+                CodedEvents=[CodedEvent(CTV3Code="bar1", effective_date="2000-01-01"),],
             ),
         ]
     )
@@ -1240,7 +1232,7 @@ def test_to_sql_passes():
     session = make_session()
     patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
-        CodedEvent(CTV3Code="XYZ", NumericValue=50, ConsultationDate="2002-06-01")
+        CodedEvent(CTV3Code="XYZ", NumericValue=50, effective_date="2002-06-01")
     )
     session.add(patient)
     session.commit()
@@ -1320,17 +1312,13 @@ def test_using_expression_in_population_definition():
             Patient(
                 gender=1,
                 date_of_birth="1970-01-01",
-                CodedEvents=[
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
-                ],
+                CodedEvents=[CodedEvent(CTV3Code="foo1", effective_date="2000-01-01")],
             ),
             Patient(gender=1, date_of_birth="1975-01-01"),
             Patient(
                 gender=2,
                 date_of_birth="1980-01-01",
-                CodedEvents=[
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
-                ],
+                CodedEvents=[CodedEvent(CTV3Code="foo1", effective_date="2000-01-01")],
             ),
             Patient(gender=2, date_of_birth="1985-01-01"),
         ]
@@ -1367,40 +1355,40 @@ def test_number_of_episodes():
         [
             Patient(
                 CodedEvents=[
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2010-01-01"),
+                    CodedEvent(CTV3Code="foo1", effective_date="2010-01-01"),
                     # Throw in some irrelevant events
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-01-02"),
-                    CodedEvent(CTV3Code="mto2", ConsultationDate="2010-01-03"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2010-01-02"),
+                    CodedEvent(CTV3Code="mto2", effective_date="2010-01-03"),
                     # These two should be merged in to the previous event
                     # because there's not more than 14 days between them
-                    CodedEvent(CTV3Code="foo2", ConsultationDate="2010-01-14"),
-                    CodedEvent(CTV3Code="foo3", ConsultationDate="2010-01-20"),
+                    CodedEvent(CTV3Code="foo2", effective_date="2010-01-14"),
+                    CodedEvent(CTV3Code="foo3", effective_date="2010-01-20"),
                     # This is just outside the limit so should count as another event
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2010-02-04"),
+                    CodedEvent(CTV3Code="foo1", effective_date="2010-02-04"),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2012-01-01T10:45:00"),
-                    CodedEvent(CTV3Code="bar2", ConsultationDate="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="foo1", effective_date="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="bar2", effective_date="2012-01-01T16:10:00"),
                     # This should be another episode
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2015-03-05"),
+                    CodedEvent(CTV3Code="foo1", effective_date="2015-03-05"),
                     # This "ignore" event should have no effect because it occurs
                     # on a different day
-                    CodedEvent(CTV3Code="bar1", ConsultationDate="2015-03-06"),
+                    CodedEvent(CTV3Code="bar1", effective_date="2015-03-06"),
                     # This is after the time limit and so shouldn't count
-                    CodedEvent(CTV3Code="foo1", ConsultationDate="2020-02-05"),
+                    CodedEvent(CTV3Code="foo1", effective_date="2020-02-05"),
                 ]
             ),
             # This patient doesn't have any relevant events
             Patient(
                 CodedEvents=[
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-01-01"),
-                    CodedEvent(CTV3Code="mto2", ConsultationDate="2010-01-14"),
-                    CodedEvent(CTV3Code="mto3", ConsultationDate="2010-01-20"),
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-02-04"),
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2012-01-01T10:45:00"),
-                    CodedEvent(CTV3Code="mtr2", ConsultationDate="2012-01-01T16:10:00"),
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2015-03-05"),
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2020-02-05"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2010-01-01"),
+                    CodedEvent(CTV3Code="mto2", effective_date="2010-01-14"),
+                    CodedEvent(CTV3Code="mto3", effective_date="2010-01-20"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2010-02-04"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="mtr2", effective_date="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2015-03-05"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2020-02-05"),
                 ]
             ),
         ]
@@ -1442,66 +1430,66 @@ def test_number_of_episodes_for_medications():
             Patient(
                 MedicationIssues=[
                     MedicationIssue(
-                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-01"
+                        MedicationDictionary=oral_steriod, effective_date="2010-01-01"
                     ),
                     # Throw in some irrelevant prescriptions
                     MedicationIssue(
-                        MedicationDictionary=other_drug, ConsultationDate="2010-01-02"
+                        MedicationDictionary=other_drug, effective_date="2010-01-02"
                     ),
                     MedicationIssue(
-                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                        MedicationDictionary=other_drug, effective_date="2010-01-03"
                     ),
                     # These two should be merged in to the previous event
                     # because there's not more than 14 days between them
                     MedicationIssue(
-                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-14"
+                        MedicationDictionary=oral_steriod, effective_date="2010-01-14"
                     ),
                     MedicationIssue(
-                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-20"
+                        MedicationDictionary=oral_steriod, effective_date="2010-01-20"
                     ),
                     # This is just outside the limit so should count as another event
                     MedicationIssue(
-                        MedicationDictionary=oral_steriod, ConsultationDate="2010-02-04"
+                        MedicationDictionary=oral_steriod, effective_date="2010-02-04"
                     ),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     MedicationIssue(
                         MedicationDictionary=oral_steriod,
-                        ConsultationDate="2012-01-01T10:45:00",
+                        effective_date="2012-01-01T10:45:00",
                     ),
                     # This should be another episode
                     MedicationIssue(
-                        MedicationDictionary=oral_steriod, ConsultationDate="2015-03-05"
+                        MedicationDictionary=oral_steriod, effective_date="2015-03-05"
                     ),
                     # This is after the time limit and so shouldn't count
                     MedicationIssue(
-                        MedicationDictionary=oral_steriod, ConsultationDate="2020-02-05"
+                        MedicationDictionary=oral_steriod, effective_date="2020-02-05"
                     ),
                 ],
                 CodedEvents=[
                     # This "ignore" event should cause us to skip one of the
                     # meds issues above
-                    CodedEvent(CTV3Code="bar2", ConsultationDate="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="bar2", effective_date="2012-01-01T16:10:00"),
                     # This "ignore" event should have no effect because it
                     # doesn't occur on the same day as any meds issue
-                    CodedEvent(CTV3Code="bar1", ConsultationDate="2015-03-06"),
+                    CodedEvent(CTV3Code="bar1", effective_date="2015-03-06"),
                 ],
             ),
             # This patient doesn't have any relevant events or prescriptions
             Patient(
                 MedicationIssues=[
                     MedicationIssue(
-                        MedicationDictionary=other_drug, ConsultationDate="2010-01-02"
+                        MedicationDictionary=other_drug, effective_date="2010-01-02"
                     ),
                     MedicationIssue(
-                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                        MedicationDictionary=other_drug, effective_date="2010-01-03"
                     ),
                 ],
                 CodedEvents=[
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-02-04"),
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2012-01-01T10:45:00"),
-                    CodedEvent(CTV3Code="mtr2", ConsultationDate="2012-01-01T16:10:00"),
-                    CodedEvent(CTV3Code="mto1", ConsultationDate="2015-03-05"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2010-02-04"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="mtr2", effective_date="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="mto1", effective_date="2015-03-05"),
                 ],
             ),
         ]
@@ -1543,19 +1531,19 @@ def test_medications_returning_code_with_ignored_days():
             Patient(
                 MedicationIssues=[
                     MedicationIssue(
-                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                        MedicationDictionary=other_drug, effective_date="2010-01-03"
                     ),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     MedicationIssue(
                         MedicationDictionary=oral_steriod,
-                        ConsultationDate="2012-01-01T10:45:00",
+                        effective_date="2012-01-01T10:45:00",
                     ),
                 ],
                 CodedEvents=[
                     # This "ignore" event should cause us to skip one of the
                     # meds issues above
-                    CodedEvent(CTV3Code="bar1", ConsultationDate="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="bar1", effective_date="2012-01-01T16:10:00"),
                 ],
             ),
         ]

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -473,10 +473,10 @@ def test_patient_registered_as_of():
     # No date criteria
     study = StudyDefinition(population=patients.registered_as_of("2002-03-02"))
     results = study.to_dicts()
-    assert [x["patient_id"] for x in results] == [
+    assert {x["patient_id"] for x in results} == {
         str(patient_registered_in_2001.Patient_ID),
         str(patient_registered_in_2002.Patient_ID),
-    ]
+    }
 
 
 def test_patients_registered_with_one_practice_between():

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -545,7 +545,7 @@ def test_simple_bmi(include_dates):
         BMI=patients.most_recent_bmi(
             on_or_after="1995-01-01", on_or_before="2005-01-01"
         ),
-        **dict(BMI_date_measured=date_query) if date_query else {}
+        **dict(BMI_date_measured=date_query) if date_query else {},
     )
     results = study.to_dicts()
     assert [x["BMI"] for x in results] == ["0.5"]

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -1438,26 +1438,6 @@ def test_duplicate_id_checking():
             study.to_csv(f.name)
 
 
-def test_sqlcmd_and_odbc_outputs_match():
-    session = make_session()
-    patient = Patient(DateOfBirth="1950-01-01")
-    patient.CodedEvents.append(
-        CodedEvent(CTV3Code="XYZ", NumericValue=50, ConsultationDate="2002-06-01")
-    )
-    session.add(patient)
-    session.commit()
-
-    study = StudyDefinition(
-        population=patients.with_these_clinical_events(codelist(["XYZ"], "ctv3"))
-    )
-    with tempfile.NamedTemporaryFile() as input_csv_odbc, tempfile.NamedTemporaryFile() as input_csv_sqlcmd:
-        # windows line endings
-        study.to_csv(input_csv_odbc.name, with_sqlcmd=False)
-        # unix line endings
-        study.to_csv(input_csv_sqlcmd.name, with_sqlcmd=True)
-        assert filecmp.cmp(input_csv_odbc.name, input_csv_sqlcmd.name, shallow=False)
-
-
 def test_column_name_clashes_produce_errors():
     with pytest.raises(ValueError):
         StudyDefinition(

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -1528,7 +1528,7 @@ def test_using_expression_in_population_definition():
 def test_quote():
     with pytest.raises(ValueError):
         quote("foo!")
-    assert quote("2012-02-01") == "'20120201'"
+    assert quote("2012-02-01") == "DATE('2012-02-01')"
     assert quote("2012") == "'2012'"
     assert quote(2012) == "2012"
     assert quote(0.1) == "0.1"

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -1,5 +1,4 @@
 import csv
-import filecmp
 import os
 import subprocess
 import tempfile
@@ -35,10 +34,7 @@ from datalab_cohorts.acme_backend import (
     quote,
     AppointmentStatus,
 )
-from datalab_cohorts.presto_utils import (
-    presto_connection_from_url,
-    presto_connection_params_from_url,
-)
+from datalab_cohorts.presto_utils import presto_connection_params_from_url
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -10,7 +10,6 @@ from tests.acme_backend_setup import (
     Observation,
     Medication,
     Patient,
-    RegistrationHistory,
     Organisation,
     PatientAddress,
     ICNARC,
@@ -50,7 +49,6 @@ def setup_function(function):
     # session.query(ONSDeaths).delete()
     # session.query(CPNS).delete()
     session.query(Medication).delete()
-    # session.query(RegistrationHistory).delete()
     # session.query(Organisation).delete()
     # session.query(PatientAddress).delete()
     session.query(Patient).delete()
@@ -417,18 +415,15 @@ def test_clinical_event_with_category():
 def test_patients_registered_with_one_practice_between():
     session = make_session()
 
-    patient_registered_in_2001 = Patient()
-    patient_registered_in_2002 = Patient()
-    patient_unregistered_in_2002 = Patient()
-    patient_registered_in_2001.RegistrationHistory = [
-        RegistrationHistory(StartDate="2001-01-01", EndDate="9999-01-01")
-    ]
-    patient_registered_in_2002.RegistrationHistory = [
-        RegistrationHistory(StartDate="2002-01-01", EndDate="9999-01-01")
-    ]
-    patient_unregistered_in_2002.RegistrationHistory = [
-        RegistrationHistory(StartDate="2001-01-01", EndDate="2002-01-01")
-    ]
+    patient_registered_in_2001 = Patient(
+        registered_date="2001-01-01", registration_end_date=None
+    )
+    patient_registered_in_2002 = Patient(
+        registered_date="2002-01-01", registration_end_date=None
+    )
+    patient_unregistered_in_2002 = Patient(
+        registered_date="2001-01-01", registration_end_date="2002-01-01"
+    )
 
     session.add(patient_registered_in_2001)
     session.add(patient_registered_in_2002)

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -86,8 +86,8 @@ def test_minimal_study_to_csv():
         study.to_csv(f.name)
         results = list(csv.DictReader(f))
         assert results == [
-            {"patient_id": str(patient_1.Patient_ID), "sex": "M"},
-            {"patient_id": str(patient_2.Patient_ID), "sex": "F"},
+            {"patient_id": str(patient_1.id), "sex": "M"},
+            {"patient_id": str(patient_2.id), "sex": "F"},
         ]
 
 
@@ -457,9 +457,7 @@ def test_patients_registered_with_one_practice_between():
         )
     )
     results = study.to_dicts()
-    assert [x["patient_id"] for x in results] == [
-        str(patient_registered_in_2001.Patient_ID)
-    ]
+    assert [x["patient_id"] for x in results] == [str(patient_registered_in_2001.id)]
 
 
 @pytest.mark.parametrize("include_dates", ["none", "year", "month", "day"])
@@ -1265,7 +1263,7 @@ def test_to_sql_passes():
     ]
     result = subprocess.run(cmd, capture_output=True, encoding="utf8").stdout
     patient_id = result.splitlines()[-1]
-    assert patient_id == f'"{patient.Patient_ID}"'
+    assert patient_id == f'"{patient.id}"'
 
 
 def test_duplicate_id_checking():

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -47,14 +47,14 @@ def setup_function(function):
     """
     session = make_session()
     session.query(CodedEvent).delete()
-    session.query(ICNARC).delete()
-    session.query(ONSDeaths).delete()
-    session.query(CPNS).delete()
+    # session.query(ICNARC).delete()
+    # session.query(ONSDeaths).delete()
+    # session.query(CPNS).delete()
     session.query(MedicationIssue).delete()
     session.query(MedicationDictionary).delete()
-    session.query(RegistrationHistory).delete()
-    session.query(Organisation).delete()
-    session.query(PatientAddress).delete()
+    # session.query(RegistrationHistory).delete()
+    # session.query(Organisation).delete()
+    # session.query(PatientAddress).delete()
     session.query(Patient).delete()
     session.commit()
 
@@ -864,6 +864,7 @@ def test_patients_categorised_as():
     assert "has_bar" not in results[0].keys()
 
 
+@pytest.mark.xfail
 def test_patients_registered_practice_as_of():
     session = make_session()
     org_1 = Organisation(
@@ -931,6 +932,7 @@ def test_patients_registered_practice_as_of():
     assert [i["pseudo_id"] for i in results] == ["3", "1", "0"]
 
 
+@pytest.mark.xfail
 def test_patients_address_as_of():
     session = make_session()
     patient = Patient()
@@ -996,6 +998,7 @@ def test_patients_address_as_of():
     assert [i["rural_urban"] for i in results] == ["2", "0", "0"]
 
 
+@pytest.mark.xfail
 def test_patients_admitted_to_icu():
     session = make_session()
     patient_1 = Patient()
@@ -1111,6 +1114,7 @@ def test_patients_admitted_to_icu():
     assert [i["icu"] for i in results] == ["1", "1", "0", "0", "1"]
 
 
+@pytest.mark.xfail
 def test_patients_with_these_codes_on_death_certificate():
     code = "COVID"
     session = make_session()
@@ -1152,6 +1156,7 @@ def test_patients_with_these_codes_on_death_certificate():
     assert [i["date_died"] for i in results] == ["", "", "", "2020-02-01", "2020-03-01"]
 
 
+@pytest.mark.xfail
 def test_patients_died_from_any_cause():
     session = make_session()
     session.add_all(
@@ -1179,6 +1184,7 @@ def test_patients_died_from_any_cause():
     assert [i["date_died"] for i in results] == ["", "", "2020-02-01"]
 
 
+@pytest.mark.xfail
 def test_patients_with_death_recorded_in_cpns():
     session = make_session()
     session.add_all(
@@ -1216,6 +1222,7 @@ def test_patients_with_death_recorded_in_cpns():
     ]
 
 
+@pytest.mark.xfail
 def test_patients_with_death_recorded_in_cpns_raises_error_on_bad_data():
     session = make_session()
     session.add_all(

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -1243,36 +1243,6 @@ def test_patients_with_death_recorded_in_cpns_raises_error_on_bad_data():
         study.to_dicts()
 
 
-def test_to_sql_passes():
-    session = make_session()
-    patient = Patient(date_of_birth="1950-01-01")
-    patient.observations.append(
-        Observation(snomed_concept_id="XYZ", value_pq_1=50, effective_date="2002-06-01")
-    )
-    session.add(patient)
-    session.commit()
-
-    study = StudyDefinition(
-        population=patients.with_these_clinical_events(codelist(["XYZ"], "ctv3"))
-    )
-    db_dict = presto_connection_params_from_url(study.backend.database_url)
-    cmd = [
-        "docker",
-        "exec",
-        "opensafely-research-template_presto_1",
-        "presto",
-        "--catalog",
-        db_dict["catalog"],
-        "--schema",
-        db_dict["schema"],
-        "--execute",
-        study.to_sql(),
-    ]
-    result = subprocess.run(cmd, capture_output=True, encoding="utf8").stdout
-    patient_id = result.splitlines()[-1]
-    assert patient_id == f'"{patient.id}"'
-
-
 def test_duplicate_id_checking():
     study = StudyDefinition(population=patients.all())
     # A bit of a hack: overwrite the queries we're going to run with a query which

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -77,8 +77,8 @@ def delete_temporary_tables():
 
 def test_minimal_study_to_csv():
     session = make_session()
-    patient_1 = Patient(DateOfBirth="1900-01-01", Sex="M")
-    patient_2 = Patient(DateOfBirth="1900-01-01", Sex="F")
+    patient_1 = Patient(date_of_birth="1900-01-01", gender=1)
+    patient_2 = Patient(date_of_birth="1900-01-01", gender=2)
     session.add_all([patient_1, patient_2])
     session.commit()
     study = StudyDefinition(population=patients.all(), sex=patients.sex())
@@ -467,7 +467,7 @@ def test_simple_bmi(include_dates):
     weight_code = "X76C7"
     height_code = "XM01E"
 
-    patient = Patient(DateOfBirth="1950-01-01")
+    patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2002-06-01")
     )
@@ -507,7 +507,7 @@ def test_bmi_rounded():
     weight_code = "X76C7"
     height_code = "XM01E"
 
-    patient = Patient(DateOfBirth="1950-01-01")
+    patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(
             CTV3Code=weight_code, NumericValue=10.12345, ConsultationDate="2001-06-01"
@@ -535,7 +535,7 @@ def test_bmi_with_zero_values():
     weight_code = "X76C7"
     height_code = "XM01E"
 
-    patient = Patient(DateOfBirth="1950-01-01")
+    patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=weight_code, NumericValue=0, ConsultationDate="2001-06-01")
     )
@@ -563,7 +563,7 @@ def test_explicit_bmi_fallback():
     weight_code = "X76C7"
     bmi_code = "22K.."
 
-    patient = Patient(DateOfBirth="1950-01-01")
+    patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2001-06-01")
     )
@@ -590,7 +590,7 @@ def test_no_bmi_when_old_date():
 
     bmi_code = "22K.."
 
-    patient = Patient(DateOfBirth="1950-01-01")
+    patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="1994-12-31")
     )
@@ -614,7 +614,7 @@ def test_no_bmi_when_measurements_of_child():
 
     bmi_code = "22K.."
 
-    patient = Patient(DateOfBirth="2000-01-01")
+    patient = Patient(date_of_birth="2000-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-01-01")
     )
@@ -638,7 +638,7 @@ def test_no_bmi_when_measurement_after_reference_date():
 
     bmi_code = "22K.."
 
-    patient = Patient(DateOfBirth="1900-01-01")
+    patient = Patient(date_of_birth="1900-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-01-01")
     )
@@ -664,7 +664,7 @@ def test_bmi_when_only_some_measurements_of_child():
     weight_code = "X76C7"
     height_code = "XM01E"
 
-    patient = Patient(DateOfBirth="1990-01-01")
+    patient = Patient(date_of_birth="1990-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="1995-01-01")
     )
@@ -730,10 +730,10 @@ def test_mean_recorded_value():
 def test_patients_satisfying():
     condition_code = "ASTHMA"
     session = make_session()
-    patient_1 = Patient(DateOfBirth="1940-01-01", Sex="M")
-    patient_2 = Patient(DateOfBirth="1940-01-01", Sex="F")
-    patient_3 = Patient(DateOfBirth="1990-01-01", Sex="M")
-    patient_4 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_1 = Patient(date_of_birth="1940-01-01", gender=1)
+    patient_2 = Patient(date_of_birth="1940-01-01", gender=2)
+    patient_3 = Patient(date_of_birth="1990-01-01", gender=1)
+    patient_4 = Patient(date_of_birth="1940-01-01", gender=2)
     patient_4.CodedEvents.append(
         CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
     )
@@ -756,14 +756,14 @@ def test_patients_satisfying_with_hidden_columns():
     condition_code = "ASTHMA"
     condition_code2 = "COPD"
     session = make_session()
-    patient_1 = Patient(DateOfBirth="1940-01-01", Sex="M")
-    patient_2 = Patient(DateOfBirth="1940-01-01", Sex="F")
-    patient_3 = Patient(DateOfBirth="1990-01-01", Sex="M")
-    patient_4 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_1 = Patient(date_of_birth="1940-01-01", gender=1)
+    patient_2 = Patient(date_of_birth="1940-01-01", gender=2)
+    patient_3 = Patient(date_of_birth="1990-01-01", gender=1)
+    patient_4 = Patient(date_of_birth="1940-01-01", gender=2)
     patient_4.CodedEvents.append(
         CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
     )
-    patient_5 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_5 = Patient(date_of_birth="1940-01-01", gender=2)
     patient_5.CodedEvents.append(
         CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
     )
@@ -800,32 +800,32 @@ def test_patients_categorised_as():
     session.add_all(
         [
             Patient(
-                Sex="M",
+                gender=1,
                 CodedEvents=[
                     CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
                 ],
             ),
             Patient(
-                Sex="F",
+                gender=2,
                 CodedEvents=[
                     CodedEvent(CTV3Code="foo2", ConsultationDate="2000-01-01"),
                     CodedEvent(CTV3Code="bar1", ConsultationDate="2000-01-01"),
                 ],
             ),
             Patient(
-                Sex="M",
+                gender=1,
                 CodedEvents=[
                     CodedEvent(CTV3Code="foo2", ConsultationDate="2000-01-01")
                 ],
             ),
             Patient(
-                Sex="F",
+                gender=2,
                 CodedEvents=[
                     CodedEvent(CTV3Code="foo3", ConsultationDate="2000-01-01")
                 ],
             ),
             Patient(
-                Sex="F",
+                gender=2,
                 CodedEvents=[
                     CodedEvent(CTV3Code="bar1", ConsultationDate="2000-01-01"),
                 ],
@@ -1238,7 +1238,7 @@ def test_patients_with_death_recorded_in_cpns_raises_error_on_bad_data():
 
 def test_to_sql_passes():
     session = make_session()
-    patient = Patient(DateOfBirth="1950-01-01")
+    patient = Patient(date_of_birth="1950-01-01")
     patient.CodedEvents.append(
         CodedEvent(CTV3Code="XYZ", NumericValue=50, ConsultationDate="2002-06-01")
     )
@@ -1318,21 +1318,21 @@ def test_using_expression_in_population_definition():
     session.add_all(
         [
             Patient(
-                Sex="M",
-                DateOfBirth="1970-01-01",
+                gender=1,
+                date_of_birth="1970-01-01",
                 CodedEvents=[
                     CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
                 ],
             ),
-            Patient(Sex="M", DateOfBirth="1975-01-01"),
+            Patient(gender=1, date_of_birth="1975-01-01"),
             Patient(
-                Sex="F",
-                DateOfBirth="1980-01-01",
+                gender=2,
+                date_of_birth="1980-01-01",
                 CodedEvents=[
                     CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
                 ],
             ),
-            Patient(Sex="F", DateOfBirth="1985-01-01"),
+            Patient(gender=2, date_of_birth="1985-01-01"),
         ]
     )
     session.commit()

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -1,0 +1,1939 @@
+import csv
+import filecmp
+import os
+import subprocess
+import tempfile
+
+import pytest
+
+from tests.acme_backend_setup import make_database, make_session
+from tests.acme_backend_setup import (
+    Appointment,
+    CodedEvent,
+    MedicationIssue,
+    MedicationDictionary,
+    Patient,
+    RegistrationHistory,
+    Organisation,
+    PatientAddress,
+    ICNARC,
+    ONSDeaths,
+    CPNS,
+    Vaccination,
+    VaccinationReference,
+    SGSS_Positive,
+    SGSS_Negative,
+    PotentialCareHomeAddress,
+)
+
+from datalab_cohorts import (
+    StudyDefinition,
+    patients,
+    codelist,
+)
+from datalab_cohorts.mssql_utils import mssql_connection_params_from_url
+from datalab_cohorts.acme_backend import (
+    quote,
+    AppointmentStatus,
+)
+
+
+@pytest.fixture(autouse=True)
+def set_database_url(monkeypatch):
+    # The StudyDefinition code expects a single DATABASE_URL to tell it where
+    # to connect to, but the test environment needs to supply multiple
+    # connections (one for each backend type) so we copy the value in here
+    if "ACME_DATABASE_URL" in os.environ:
+        monkeypatch.setenv("DATABASE_URL", os.environ["ACME_DATABASE_URL"])
+
+
+def setup_module(module):
+    make_database()
+
+
+def setup_function(function):
+    """
+    Ensure test database is empty
+    """
+    session = make_session()
+    session.query(CodedEvent).delete()
+    session.query(ICNARC).delete()
+    session.query(ONSDeaths).delete()
+    session.query(CPNS).delete()
+    session.query(Vaccination).delete()
+    session.query(VaccinationReference).delete()
+    session.query(Appointment).delete()
+    session.query(SGSS_Positive).delete()
+    session.query(SGSS_Negative).delete()
+    session.query(MedicationIssue).delete()
+    session.query(MedicationDictionary).delete()
+    session.query(RegistrationHistory).delete()
+    session.query(Organisation).delete()
+    session.query(PotentialCareHomeAddress).delete()
+    session.query(PatientAddress).delete()
+    session.query(Patient).delete()
+    session.commit()
+
+
+def test_minimal_study_to_csv():
+    session = make_session()
+    patient_1 = Patient(DateOfBirth="1900-01-01", Sex="M")
+    patient_2 = Patient(DateOfBirth="1900-01-01", Sex="F")
+    session.add_all([patient_1, patient_2])
+    session.commit()
+    study = StudyDefinition(population=patients.all(), sex=patients.sex())
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        study.to_csv(f.name)
+        results = list(csv.DictReader(f))
+        assert results == [
+            {"patient_id": str(patient_1.Patient_ID), "sex": "M"},
+            {"patient_id": str(patient_2.Patient_ID), "sex": "F"},
+        ]
+
+
+def test_meds():
+    session = make_session()
+
+    asthma_medication = MedicationDictionary(
+        FullName="Asthma Drug", DMD_ID="0", MultilexDrug_ID="0"
+    )
+    patient_with_med = Patient()
+    patient_with_med.MedicationIssues = [
+        MedicationIssue(MedicationDictionary=asthma_medication)
+    ]
+    patient_without_med = Patient()
+    session.add(patient_with_med)
+    session.add(patient_without_med)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_meds=patients.with_these_medications(
+            codelist(asthma_medication.DMD_ID, "snomed")
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_meds"] for x in results] == ["1", "0"]
+
+
+def test_meds_with_count():
+    session = make_session()
+
+    asthma_medication = MedicationDictionary(
+        FullName="Asthma Drug", DMD_ID="0", MultilexDrug_ID="0"
+    )
+    patient_with_med = Patient()
+    patient_with_med.MedicationIssues = [
+        MedicationIssue(
+            MedicationDictionary=asthma_medication, ConsultationDate="2010-01-01"
+        ),
+        MedicationIssue(
+            MedicationDictionary=asthma_medication, ConsultationDate="2015-01-01"
+        ),
+        MedicationIssue(
+            MedicationDictionary=asthma_medication, ConsultationDate="2018-01-01"
+        ),
+        MedicationIssue(
+            MedicationDictionary=asthma_medication, ConsultationDate="2020-01-01"
+        ),
+    ]
+    patient_without_med = Patient()
+    session.add(patient_with_med)
+    session.add(patient_without_med)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_meds=patients.with_these_medications(
+            codelist(asthma_medication.DMD_ID, "snomed"),
+            on_or_after="2012-01-01",
+            return_number_of_matches_in_period=True,
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_meds"] for x in results] == ["3", "0"]
+
+
+def _make_clinical_events_selection(condition_code, patient_dates=None):
+    # The default configuration of patients and dates which some tests assume
+    if patient_dates is None:
+        patient_dates = ["2001-06-01", "2002-06-01", None]
+    session = make_session()
+    for dates in patient_dates:
+        patient = Patient()
+        if dates is None:
+            dates = []
+        elif isinstance(dates, str):
+            dates = [dates]
+        for date in dates:
+            if isinstance(date, tuple):
+                date, value = date
+            else:
+                value = 0.0
+            patient.CodedEvents.append(
+                CodedEvent(
+                    CTV3Code=condition_code, ConsultationDate=date, NumericValue=value
+                )
+            )
+        session.add(patient)
+    session.commit()
+
+
+def test_clinical_event_without_filters():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(condition_code)
+    # No date criteria
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3")
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["1", "1", "0"]
+
+
+def test_clinical_event_with_max_date():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(condition_code)
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"), on_or_before="2001-12-01"
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["1", "0", "0"]
+
+
+def test_clinical_event_with_min_date():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(condition_code)
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"), on_or_after="2005-12-01"
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["0", "0", "0"]
+
+
+def test_clinical_event_with_min_and_max_date():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(condition_code)
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"), between=["2001-12-01", "2002-06-01"]
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["0", "1", "0"]
+
+
+def test_clinical_event_returning_first_date():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(
+        condition_code,
+        patient_dates=[
+            None,
+            # Include date before period starts, which should be ignored
+            ["2001-01-01", "2002-06-01"],
+            ["2001-06-01"],
+        ],
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            between=["2001-12-01", "2002-06-01"],
+            returning="date",
+            find_first_match_in_period=True,
+            date_format="YYYY-MM-DD",
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["", "2002-06-01", ""]
+
+
+def test_clinical_event_returning_last_date():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(
+        condition_code,
+        patient_dates=[
+            None,
+            # Include date after period ends, which should be ignored
+            ["2002-06-01", "2003-01-01"],
+            ["2001-06-01"],
+        ],
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            between=["2001-12-01", "2002-06-01"],
+            returning="date",
+            find_last_match_in_period=True,
+            date_format="YYYY-MM-DD",
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["", "2002-06-01", ""]
+
+
+def test_clinical_event_returning_year_only():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(condition_code)
+    # No date criteria
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            returning="date",
+            find_first_match_in_period=True,
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["2001", "2002", ""]
+
+
+def test_clinical_event_returning_year_and_month_only():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(condition_code)
+    # No date criteria
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_condition=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            returning="date",
+            find_first_match_in_period=True,
+            date_format="YYYY-MM",
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_condition"] for x in results] == ["2001-06", "2002-06", ""]
+
+
+def test_clinical_event_with_count():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(
+        condition_code,
+        patient_dates=[
+            None,
+            # Include date before period starts, which should be ignored
+            ["2001-01-01", "2002-01-01", "2002-02-01", "2002-06-01"],
+            ["2001-06-01"],
+        ],
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_count=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            between=["2001-12-01", "2002-06-01"],
+            returning="number_of_matches_in_period",
+            find_first_match_in_period=True,
+        ),
+        asthma_count_date=patients.date_of("asthma_count", date_format="YYYY-MM"),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_count"] for x in results] == ["0", "3", "0"]
+    assert [x["asthma_count_date"] for x in results] == ["", "2002-01", ""]
+
+
+def test_clinical_event_with_code():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(
+        condition_code,
+        patient_dates=[
+            None,
+            # Include date before period starts, which should be ignored
+            ["2001-01-01", "2002-01-01", "2002-02-01", "2002-06-01"],
+            ["2001-06-01"],
+        ],
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        latest_asthma_code=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            between=["2001-12-01", "2002-06-01"],
+            returning="code",
+            find_last_match_in_period=True,
+        ),
+        latest_asthma_code_date=patients.date_of(
+            "latest_asthma_code", date_format="YYYY-MM"
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["latest_asthma_code"] for x in results] == ["", condition_code, ""]
+    assert [x["latest_asthma_code_date"] for x in results] == ["", "2002-06", ""]
+
+
+def test_clinical_event_with_numeric_value():
+    condition_code = "ASTHMA"
+    _make_clinical_events_selection(
+        condition_code,
+        patient_dates=[
+            None,
+            # Include date before period starts, which should be ignored
+            [
+                ("2001-01-01", 1),
+                ("2002-01-01", 2),
+                ("2002-02-01", 3),
+                ("2002-06-01", 4),
+            ],
+            [("2001-06-01", 7)],
+        ],
+    )
+    study = StudyDefinition(
+        population=patients.all(),
+        asthma_value=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3"),
+            between=["2001-12-01", "2002-06-01"],
+            returning="numeric_value",
+            find_first_match_in_period=True,
+        ),
+        asthma_value_date=patients.date_of("asthma_value", date_format="YYYY-MM"),
+    )
+    results = study.to_dicts()
+    assert [x["asthma_value"] for x in results] == ["0.0", "2.0", "0.0"]
+    assert [x["asthma_value_date"] for x in results] == ["", "2002-01", ""]
+
+
+def test_clinical_event_with_category():
+    session = make_session()
+    session.add_all(
+        [
+            Patient(),
+            Patient(
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2018-01-01"),
+                    CodedEvent(CTV3Code="foo2", ConsultationDate="2020-01-01"),
+                ]
+            ),
+            Patient(
+                CodedEvents=[CodedEvent(CTV3Code="foo3", ConsultationDate="2019-01-01")]
+            ),
+        ]
+    )
+    session.commit()
+    codes = codelist([("foo1", "A"), ("foo2", "B"), ("foo3", "C")], "ctv3")
+    study = StudyDefinition(
+        population=patients.all(),
+        code_category=patients.with_these_clinical_events(
+            codes, returning="category", find_last_match_in_period=True
+        ),
+        code_category_date=patients.date_of("code_category"),
+    )
+    results = study.to_dicts()
+    assert [x["code_category"] for x in results] == ["", "B", "C"]
+    assert [x["code_category_date"] for x in results] == ["", "2020", "2019"]
+
+
+def test_patient_registered_as_of():
+    session = make_session()
+
+    patient_registered_in_2001 = Patient()
+    patient_registered_in_2002 = Patient()
+    patient_unregistered_in_2002 = Patient()
+    patient_registered_in_2001.RegistrationHistory = [
+        RegistrationHistory(StartDate="2001-01-01", EndDate="9999-01-01")
+    ]
+    patient_registered_in_2002.RegistrationHistory = [
+        RegistrationHistory(StartDate="2002-01-01", EndDate="9999-01-01")
+    ]
+    patient_unregistered_in_2002.RegistrationHistory = [
+        RegistrationHistory(StartDate="2001-01-01", EndDate="2002-01-01")
+    ]
+
+    session.add(patient_registered_in_2001)
+    session.add(patient_registered_in_2002)
+    session.add(patient_unregistered_in_2002)
+    session.commit()
+
+    # No date criteria
+    study = StudyDefinition(population=patients.registered_as_of("2002-03-02"))
+    results = study.to_dicts()
+    assert [x["patient_id"] for x in results] == [
+        str(patient_registered_in_2001.Patient_ID),
+        str(patient_registered_in_2002.Patient_ID),
+    ]
+
+
+def test_patients_registered_with_one_practice_between():
+    session = make_session()
+
+    patient_registered_in_2001 = Patient()
+    patient_registered_in_2002 = Patient()
+    patient_unregistered_in_2002 = Patient()
+    patient_registered_in_2001.RegistrationHistory = [
+        RegistrationHistory(StartDate="2001-01-01", EndDate="9999-01-01")
+    ]
+    patient_registered_in_2002.RegistrationHistory = [
+        RegistrationHistory(StartDate="2002-01-01", EndDate="9999-01-01")
+    ]
+    patient_unregistered_in_2002.RegistrationHistory = [
+        RegistrationHistory(StartDate="2001-01-01", EndDate="2002-01-01")
+    ]
+
+    session.add(patient_registered_in_2001)
+    session.add(patient_registered_in_2002)
+    session.add(patient_unregistered_in_2002)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.registered_with_one_practice_between(
+            "2001-12-01", "2003-01-01"
+        )
+    )
+    results = study.to_dicts()
+    assert [x["patient_id"] for x in results] == [
+        str(patient_registered_in_2001.Patient_ID)
+    ]
+
+
+@pytest.mark.parametrize("include_dates", ["none", "year", "month", "day"])
+def test_simple_bmi(include_dates):
+    session = make_session()
+
+    weight_code = "X76C7"
+    height_code = "XM01E"
+
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2002-06-01")
+    )
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=height_code, NumericValue=10, ConsultationDate="2001-06-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    if include_dates == "none":
+        bmi_date = None
+        date_query = None
+    elif include_dates == "year":
+        bmi_date = "2002"
+        date_query = patients.date_of("BMI")
+    elif include_dates == "month":
+        bmi_date = "2002-06"
+        date_query = patients.date_of("BMI", date_format="YYYY-MM")
+    elif include_dates == "day":
+        bmi_date = "2002-06-01"
+        date_query = patients.date_of("BMI", date_format="YYYY-MM-DD")
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="1995-01-01", on_or_before="2005-01-01"
+        ),
+        **dict(BMI_date_measured=date_query) if date_query else {}
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.5"]
+    assert [x.get("BMI_date_measured") for x in results] == [bmi_date]
+
+
+def test_bmi_rounded():
+    session = make_session()
+
+    weight_code = "X76C7"
+    height_code = "XM01E"
+
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(
+            CTV3Code=weight_code, NumericValue=10.12345, ConsultationDate="2001-06-01"
+        )
+    )
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=height_code, NumericValue=10, ConsultationDate="2000-02-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi("2005-01-01",),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.1"]
+    assert [x["BMI_date_measured"] for x in results] == ["2001-06-01"]
+
+
+def test_bmi_with_zero_values():
+    session = make_session()
+
+    weight_code = "X76C7"
+    height_code = "XM01E"
+
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=weight_code, NumericValue=0, ConsultationDate="2001-06-01")
+    )
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=height_code, NumericValue=0, ConsultationDate="2001-06-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="1995-01-01", on_or_before="2005-01-01",
+        ),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.0"]
+    assert [x["BMI_date_measured"] for x in results] == ["2001-06-01"]
+
+
+def test_explicit_bmi_fallback():
+    session = make_session()
+
+    weight_code = "X76C7"
+    bmi_code = "22K.."
+
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2001-06-01")
+    )
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-10-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="1995-01-01", on_or_before="2005-01-01",
+        ),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["99.0"]
+    assert [x["BMI_date_measured"] for x in results] == ["2001-10-01"]
+
+
+def test_no_bmi_when_old_date():
+    session = make_session()
+
+    bmi_code = "22K.."
+
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="1994-12-31")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="1995-01-01", on_or_before="2005-01-01",
+        ),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.0"]
+    assert [x["BMI_date_measured"] for x in results] == [""]
+
+
+def test_no_bmi_when_measurements_of_child():
+    session = make_session()
+
+    bmi_code = "22K.."
+
+    patient = Patient(DateOfBirth="2000-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-01-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="1995-01-01", on_or_before="2005-01-01",
+        ),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.0"]
+    assert [x["BMI_date_measured"] for x in results] == [""]
+
+
+def test_no_bmi_when_measurement_after_reference_date():
+    session = make_session()
+
+    bmi_code = "22K.."
+
+    patient = Patient(DateOfBirth="1900-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="2001-01-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="1990-01-01", on_or_before="2000-01-01",
+        ),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.0"]
+    assert [x["BMI_date_measured"] for x in results] == [""]
+
+
+def test_bmi_when_only_some_measurements_of_child():
+    session = make_session()
+
+    bmi_code = "22K.."
+    weight_code = "X76C7"
+    height_code = "XM01E"
+
+    patient = Patient(DateOfBirth="1990-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=bmi_code, NumericValue=99, ConsultationDate="1995-01-01")
+    )
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=weight_code, NumericValue=50, ConsultationDate="2010-01-01")
+    )
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code=height_code, NumericValue=10, ConsultationDate="2010-01-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        BMI=patients.most_recent_bmi(
+            on_or_after="2005-01-01", on_or_before="2015-01-01",
+        ),
+        BMI_date_measured=patients.date_of("BMI", date_format="YYYY-MM-DD"),
+    )
+    results = study.to_dicts()
+    assert [x["BMI"] for x in results] == ["0.5"]
+    assert [x["BMI_date_measured"] for x in results] == ["2010-01-01"]
+
+
+def test_mean_recorded_value():
+    code = "2469."
+    session = make_session()
+    patient = Patient()
+    values = [
+        ("2020-02-10", 90),
+        ("2020-02-10", 100),
+        ("2020-02-10", 98),
+        # This day is outside period and should be ignored
+        ("2020-04-01", 110),
+    ]
+    for date, value in values:
+        patient.CodedEvents.append(
+            CodedEvent(CTV3Code=code, NumericValue=value, ConsultationDate=date)
+        )
+    patient_with_old_reading = Patient()
+    patient_with_old_reading.CodedEvents.append(
+        CodedEvent(CTV3Code=code, NumericValue=100, ConsultationDate="2010-01-01")
+    )
+    patient_with_no_reading = Patient()
+    session.add_all([patient, patient_with_old_reading, patient_with_no_reading])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        bp_systolic=patients.mean_recorded_value(
+            codelist([code], system="ctv3"),
+            on_most_recent_day_of_measurement=True,
+            between=["2018-01-01", "2020-03-01"],
+        ),
+        bp_systolic_date_measured=patients.date_of(
+            "bp_systolic", date_format="YYYY-MM-DD"
+        ),
+    )
+    results = study.to_dicts()
+    results = [(i["bp_systolic"], i["bp_systolic_date_measured"]) for i in results]
+    assert results == [("96.0", "2020-02-10"), ("0.0", ""), ("0.0", "")]
+
+
+def test_patient_random_sample():
+    session = make_session()
+    sample_size = 1000
+    for _ in range(sample_size):
+        patient = Patient()
+        session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(population=patients.random_sample(percent=20))
+    results = study.to_dicts()
+    # The method is approximate!
+    assert len(results) < (sample_size / 2)
+
+
+def test_patients_satisfying():
+    condition_code = "ASTHMA"
+    session = make_session()
+    patient_1 = Patient(DateOfBirth="1940-01-01", Sex="M")
+    patient_2 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_3 = Patient(DateOfBirth="1990-01-01", Sex="M")
+    patient_4 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_4.CodedEvents.append(
+        CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
+    )
+    session.add_all([patient_1, patient_2, patient_3, patient_4])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        sex=patients.sex(),
+        age=patients.age_as_of("2020-01-01"),
+        has_asthma=patients.with_these_clinical_events(
+            codelist([condition_code], "ctv3")
+        ),
+        at_risk=patients.satisfying("(age > 70 AND sex = 'M') OR has_asthma"),
+    )
+    results = study.to_dicts()
+    assert [i["at_risk"] for i in results] == ["1", "0", "0", "1"]
+
+
+def test_patients_satisfying_with_hidden_columns():
+    condition_code = "ASTHMA"
+    condition_code2 = "COPD"
+    session = make_session()
+    patient_1 = Patient(DateOfBirth="1940-01-01", Sex="M")
+    patient_2 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_3 = Patient(DateOfBirth="1990-01-01", Sex="M")
+    patient_4 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_4.CodedEvents.append(
+        CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
+    )
+    patient_5 = Patient(DateOfBirth="1940-01-01", Sex="F")
+    patient_5.CodedEvents.append(
+        CodedEvent(CTV3Code=condition_code, ConsultationDate="2010-01-01")
+    )
+    patient_5.CodedEvents.append(
+        CodedEvent(CTV3Code=condition_code2, ConsultationDate="2010-01-01")
+    )
+    session.add_all([patient_1, patient_2, patient_3, patient_4, patient_5])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        sex=patients.sex(),
+        age=patients.age_as_of("2020-01-01"),
+        at_risk=patients.satisfying(
+            """
+            (age > 70 AND sex = "M")
+            OR
+            (has_asthma AND NOT copd)
+            """,
+            has_asthma=patients.with_these_clinical_events(
+                codelist([condition_code], "ctv3")
+            ),
+            copd=patients.with_these_clinical_events(
+                codelist([condition_code2], "ctv3")
+            ),
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["at_risk"] for i in results] == ["1", "0", "0", "1", "0"]
+    assert "has_asthma" not in results[0].keys()
+
+
+def test_patients_categorised_as():
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                Sex="M",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
+                ],
+            ),
+            Patient(
+                Sex="F",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo2", ConsultationDate="2000-01-01"),
+                    CodedEvent(CTV3Code="bar1", ConsultationDate="2000-01-01"),
+                ],
+            ),
+            Patient(
+                Sex="M",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo2", ConsultationDate="2000-01-01")
+                ],
+            ),
+            Patient(
+                Sex="F",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo3", ConsultationDate="2000-01-01")
+                ],
+            ),
+            Patient(
+                Sex="F",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="bar1", ConsultationDate="2000-01-01"),
+                ],
+            ),
+        ]
+    )
+    session.commit()
+    foo_codes = codelist([("foo1", "A"), ("foo2", "B"), ("foo3", "C")], "ctv3")
+    bar_codes = codelist(["bar1"], "ctv3")
+    study = StudyDefinition(
+        population=patients.all(),
+        category=patients.categorised_as(
+            {
+                "W": "(foo_category = 'B' OR NOT foo_category) AND female_with_bar",
+                "X": "sex = 'F' AND (foo_category = 'B' OR foo_category = 'C')",
+                "Y": "sex = 'M' AND foo_category = 'A'",
+                "Z": "DEFAULT",
+            },
+            sex=patients.sex(),
+            foo_category=patients.with_these_clinical_events(
+                foo_codes, returning="category", find_last_match_in_period=True
+            ),
+            female_with_bar=patients.satisfying(
+                "has_bar AND sex = 'F'",
+                has_bar=patients.with_these_clinical_events(bar_codes),
+            ),
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["category"] for x in results] == ["Y", "W", "Z", "X", "W"]
+    # Assert that internal columns do not appear
+    assert "foo_category" not in results[0].keys()
+    assert "female_with_bar" not in results[0].keys()
+    assert "has_bar" not in results[0].keys()
+
+
+def test_patients_registered_practice_as_of():
+    session = make_session()
+    org_1 = Organisation(
+        STPCode="123", MSOACode="E0201", Region="East of England", Organisation_ID=1
+    )
+    org_2 = Organisation(
+        STPCode="456", MSOACode="E0202", Region="Midlands", Organisation_ID=2
+    )
+    org_3 = Organisation(
+        STPCode="789", MSOACode="E0203", Region="London", Organisation_ID=3
+    )
+    org_4 = Organisation(
+        STPCode="910", MSOACode="E0204", Region="North West", Organisation_ID=4
+    )
+    patient = Patient()
+    patient.RegistrationHistory.append(
+        RegistrationHistory(
+            StartDate="1990-01-01", EndDate="2018-01-01", Organisation=org_1
+        )
+    )
+    # We deliberately create overlapping registration periods so we can check
+    # that we handle these correctly
+    patient.RegistrationHistory.append(
+        RegistrationHistory(
+            StartDate="2018-01-01", EndDate="2022-01-01", Organisation=org_2
+        )
+    )
+    patient.RegistrationHistory.append(
+        RegistrationHistory(
+            StartDate="2019-09-01", EndDate="2020-05-01", Organisation=org_3
+        )
+    )
+    patient.RegistrationHistory.append(
+        RegistrationHistory(
+            StartDate="2022-01-01", EndDate="9999-12-31", Organisation=org_4
+        )
+    )
+    patient_2 = Patient()
+    patient_2.RegistrationHistory.append(
+        RegistrationHistory(
+            StartDate="2010-01-01", EndDate="9999-12-31", Organisation=org_1
+        )
+    )
+    patient_3 = Patient()
+    patient_3.RegistrationHistory.append(
+        RegistrationHistory(StartDate="2010-01-01", EndDate="9999-12-31")
+    )
+    session.add_all([patient, patient_2, patient_3])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        stp=patients.registered_practice_as_of("2020-01-01", returning="stp_code"),
+        msoa=patients.registered_practice_as_of("2020-01-01", returning="msoa_code"),
+        region=patients.registered_practice_as_of(
+            "2020-01-01", returning="nhse_region_name"
+        ),
+        pseudo_id=patients.registered_practice_as_of(
+            "2020-01-01", returning="pseudo_id"
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["stp"] for i in results] == ["789", "123", ""]
+    assert [i["msoa"] for i in results] == ["E0203", "E0201", ""]
+    assert [i["region"] for i in results] == ["London", "East of England", ""]
+    assert [i["pseudo_id"] for i in results] == ["3", "1", "0"]
+
+
+def test_patients_address_as_of():
+    session = make_session()
+    patient = Patient()
+    patient.Addresses.append(
+        PatientAddress(
+            StartDate="1990-01-01",
+            EndDate="2018-01-01",
+            ImdRankRounded=100,
+            RuralUrbanClassificationCode=1,
+        )
+    )
+    # We deliberately create overlapping address periods here to check that we
+    # handle these correctly
+    patient.Addresses.append(
+        PatientAddress(
+            StartDate="2018-01-01",
+            EndDate="2020-02-01",
+            ImdRankRounded=200,
+            RuralUrbanClassificationCode=1,
+        )
+    )
+    patient.Addresses.append(
+        PatientAddress(
+            StartDate="2019-01-01",
+            EndDate="2022-01-01",
+            ImdRankRounded=300,
+            RuralUrbanClassificationCode=2,
+        )
+    )
+    patient.Addresses.append(
+        PatientAddress(
+            StartDate="2022-01-01",
+            EndDate="9999-12-31",
+            ImdRankRounded=500,
+            RuralUrbanClassificationCode=3,
+        )
+    )
+    patient_no_address = Patient()
+    patient_only_old_address = Patient()
+    patient_only_old_address.Addresses.append(
+        PatientAddress(
+            StartDate="2010-01-01",
+            EndDate="2015-01-01",
+            ImdRankRounded=100,
+            RuralUrbanClassificationCode=1,
+        )
+    )
+    session.add_all([patient, patient_no_address, patient_only_old_address])
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        imd=patients.address_as_of(
+            "2020-01-01",
+            returning="index_of_multiple_deprivation",
+            round_to_nearest=100,
+        ),
+        rural_urban=patients.address_as_of(
+            "2020-01-01", returning="rural_urban_classification"
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["imd"] for i in results] == ["300", "0", "0"]
+    assert [i["rural_urban"] for i in results] == ["2", "0", "0"]
+
+
+def test_patients_care_home_status_as_of():
+    session = make_session()
+    session.add_all(
+        [
+            # Was in care home but no longer
+            Patient(
+                Addresses=[
+                    PatientAddress(
+                        StartDate="2010-01-01",
+                        EndDate="2015-01-01",
+                        PotentialCareHomeAddress=[PotentialCareHomeAddress()],
+                    ),
+                    PatientAddress(StartDate="2015-01-01", EndDate="9999-01-01"),
+                ]
+            ),
+            # Currently in non-nursing care home
+            Patient(
+                Addresses=[
+                    PatientAddress(
+                        StartDate="2015-01-01",
+                        EndDate="9999-01-01",
+                        PotentialCareHomeAddress=[
+                            PotentialCareHomeAddress(
+                                LocationRequiresNursing="N",
+                                LocationDoesNotRequireNursing="Y",
+                            )
+                        ],
+                    ),
+                ]
+            ),
+            # Currently in nursing home
+            Patient(
+                Addresses=[
+                    PatientAddress(
+                        StartDate="2015-01-01",
+                        EndDate="9999-01-01",
+                        PotentialCareHomeAddress=[
+                            PotentialCareHomeAddress(
+                                LocationRequiresNursing="Y",
+                                LocationDoesNotRequireNursing="N",
+                            )
+                        ],
+                    ),
+                ]
+            ),
+            # Currently in a schrodin-home which both does and does not require nursing
+            Patient(
+                Addresses=[
+                    PatientAddress(
+                        StartDate="2015-01-01",
+                        EndDate="9999-01-01",
+                        PotentialCareHomeAddress=[
+                            PotentialCareHomeAddress(
+                                LocationRequiresNursing="Y",
+                                LocationDoesNotRequireNursing="Y",
+                            )
+                        ],
+                    ),
+                ]
+            ),
+        ]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        is_in_care_home=patients.care_home_status_as_of("2020-01-01"),
+        care_home_type=patients.care_home_status_as_of(
+            "2020-01-01",
+            categorised_as={
+                "PC": """
+                  IsPotentialCareHome
+                  AND LocationDoesNotRequireNursing='Y'
+                  AND LocationRequiresNursing='N'
+                """,
+                "PN": """
+                  IsPotentialCareHome
+                  AND LocationDoesNotRequireNursing='N'
+                  AND LocationRequiresNursing='Y'
+                """,
+                "PS": "IsPotentialCareHome",
+                "U": "DEFAULT",
+            },
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["is_in_care_home"] for i in results] == ["0", "1", "1", "1"]
+    assert [i["care_home_type"] for i in results] == ["U", "PC", "PN", "PS"]
+
+
+def test_patients_admitted_to_icu():
+    session = make_session()
+    patient_1 = Patient()
+    patient_1.ICNARC.append(
+        ICNARC(
+            IcuAdmissionDateTime="2020-03-01",
+            OriginalIcuAdmissionDate="2020-03-01",
+            BasicDays_RespiratorySupport=2,
+            AdvancedDays_RespiratorySupport=2,
+            Ventilator=0,
+        )
+    )
+    patient_2 = Patient()
+    patient_2.ICNARC.append(
+        ICNARC(
+            IcuAdmissionDateTime="2020-03-01",
+            OriginalIcuAdmissionDate="2020-02-01",
+            BasicDays_RespiratorySupport=1,
+            AdvancedDays_RespiratorySupport=0,
+            Ventilator=1,
+        )
+    )
+    patient_3 = Patient()
+    patient_3.ICNARC.append(
+        ICNARC(
+            IcuAdmissionDateTime="2020-03-01",
+            OriginalIcuAdmissionDate="2020-02-01",
+            BasicDays_RespiratorySupport=0,
+            AdvancedDays_RespiratorySupport=0,
+            Ventilator=0,
+        )
+    )
+    patient_4 = Patient()
+    patient_4.ICNARC.append(
+        ICNARC(
+            IcuAdmissionDateTime="2020-01-01",
+            OriginalIcuAdmissionDate="2020-01-01",
+            BasicDays_RespiratorySupport=1,
+            AdvancedDays_RespiratorySupport=0,
+            Ventilator=1,
+        )
+    )
+    patient_5 = Patient()
+    patient_5.ICNARC.append(
+        ICNARC(
+            IcuAdmissionDateTime="2020-03-01",
+            OriginalIcuAdmissionDate=None,
+            BasicDays_RespiratorySupport=1,
+            AdvancedDays_RespiratorySupport=0,
+            Ventilator=1,
+        )
+    )
+    patient_5.ICNARC.append(
+        ICNARC(
+            IcuAdmissionDateTime="2020-04-01",
+            OriginalIcuAdmissionDate=None,
+            BasicDays_RespiratorySupport=0,
+            AdvancedDays_RespiratorySupport=0,
+            Ventilator=1,
+        )
+    )
+    session.add_all([patient_1, patient_2, patient_3, patient_4, patient_5])
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        icu=patients.admitted_to_icu(
+            on_or_after="2020-02-01",
+            include_day=True,
+            returning="date_admitted",
+            find_first_match_in_period=True,
+        ),
+    )
+    results = study.to_dicts()
+
+    assert [i["icu"] for i in results] == [
+        "2020-03-01",
+        "2020-02-01",
+        "",
+        "",
+        "2020-03-01",
+    ]
+
+    study = StudyDefinition(
+        population=patients.all(),
+        icu=patients.admitted_to_icu(
+            on_or_after="2020-02-01",
+            include_day=True,
+            returning="date_admitted",
+            find_last_match_in_period=True,
+        ),
+    )
+    results = study.to_dicts()
+
+    assert [i["icu"] for i in results] == [
+        "2020-03-01",
+        "2020-02-01",
+        "",
+        "",
+        "2020-04-01",
+    ]
+
+    study = StudyDefinition(
+        population=patients.all(),
+        icu=patients.admitted_to_icu(on_or_after="2020-02-01", returning="binary_flag"),
+    )
+    results = study.to_dicts()
+
+    assert [i["icu"] for i in results] == ["1", "1", "0", "0", "1"]
+
+
+def test_patients_with_these_codes_on_death_certificate():
+    code = "COVID"
+    session = make_session()
+    session.add_all(
+        [
+            # Not dead
+            Patient(),
+            # Died after date cutoff
+            Patient(ONSDeath=[ONSDeaths(dod="2021-01-01", icd10u=code)]),
+            # Died of something else
+            Patient(ONSDeath=[ONSDeaths(dod="2020-02-01", icd10u="MI")]),
+            # Covid underlying cause
+            Patient(ONSDeath=[ONSDeaths(dod="2020-02-01", icd10u=code)]),
+            # Covid not underlying cause
+            Patient(ONSDeath=[ONSDeaths(dod="2020-03-01", ICD10014=code)]),
+        ]
+    )
+    session.commit()
+    covid_codelist = codelist([code], system="icd10")
+    study = StudyDefinition(
+        population=patients.all(),
+        died_of_covid=patients.with_these_codes_on_death_certificate(
+            covid_codelist, on_or_before="2020-06-01", match_only_underlying_cause=True
+        ),
+        died_with_covid=patients.with_these_codes_on_death_certificate(
+            covid_codelist, on_or_before="2020-06-01", match_only_underlying_cause=False
+        ),
+        date_died=patients.with_these_codes_on_death_certificate(
+            covid_codelist,
+            on_or_before="2020-06-01",
+            match_only_underlying_cause=False,
+            returning="date_of_death",
+            date_format="YYYY-MM-DD",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["died_of_covid"] for i in results] == ["0", "0", "0", "1", "0"]
+    assert [i["died_with_covid"] for i in results] == ["0", "0", "0", "1", "1"]
+    assert [i["date_died"] for i in results] == ["", "", "", "2020-02-01", "2020-03-01"]
+
+
+def test_patients_died_from_any_cause():
+    session = make_session()
+    session.add_all(
+        [
+            # Not dead
+            Patient(),
+            # Died after date cutoff
+            Patient(ONSDeath=[ONSDeaths(dod="2021-01-01")]),
+            # Died
+            Patient(ONSDeath=[ONSDeaths(dod="2020-02-01")]),
+        ]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        died=patients.died_from_any_cause(on_or_before="2020-06-01"),
+        date_died=patients.died_from_any_cause(
+            on_or_before="2020-06-01",
+            returning="date_of_death",
+            date_format="YYYY-MM-DD",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["died"] for i in results] == ["0", "0", "1"]
+    assert [i["date_died"] for i in results] == ["", "", "2020-02-01"]
+
+
+def test_patients_with_death_recorded_in_cpns():
+    session = make_session()
+    session.add_all(
+        [
+            # Not dead
+            Patient(),
+            # Died after date cutoff
+            Patient(CPNS=[CPNS(DateOfDeath="2021-01-01")]),
+            # Patient should be included
+            Patient(CPNS=[CPNS(DateOfDeath="2020-02-01")]),
+            # Patient has multple entries but with the same date of death so
+            # should be handled correctly
+            Patient(
+                CPNS=[CPNS(DateOfDeath="2020-03-01"), CPNS(DateOfDeath="2020-03-01")]
+            ),
+        ]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        cpns_death=patients.with_death_recorded_in_cpns(on_or_before="2020-06-01"),
+        cpns_death_date=patients.with_death_recorded_in_cpns(
+            on_or_before="2020-06-01",
+            returning="date_of_death",
+            date_format="YYYY-MM-DD",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["cpns_death"] for i in results] == ["0", "0", "1", "1"]
+    assert [i["cpns_death_date"] for i in results] == [
+        "",
+        "",
+        "2020-02-01",
+        "2020-03-01",
+    ]
+
+
+def test_patients_with_death_recorded_in_cpns_raises_error_on_bad_data():
+    session = make_session()
+    session.add_all(
+        # Create a patient with duplicate CPNS entries recording an
+        # inconsistent date of death
+        [Patient(CPNS=[CPNS(DateOfDeath="2020-03-01"), CPNS(DateOfDeath="2020-02-01")])]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(), cpns_death=patients.with_death_recorded_in_cpns()
+    )
+    with pytest.raises(Exception):
+        study.to_dicts()
+
+
+def test_to_sql_passes():
+    session = make_session()
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code="XYZ", NumericValue=50, ConsultationDate="2002-06-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.with_these_clinical_events(codelist(["XYZ"], "ctv3"))
+    )
+    sql = "SET NOCOUNT ON; "  # don't output count after table output
+    sql += study.to_sql()
+    db_dict = mssql_connection_params_from_url(study.backend.database_url)
+    cmd = [
+        "sqlcmd",
+        "-S",
+        db_dict["host"] + "," + str(db_dict["port"]),
+        "-d",
+        db_dict["database"],
+        "-U",
+        db_dict["username"],
+        "-P",
+        db_dict["password"],
+        "-Q",
+        sql,
+        "-W",  # strip whitespace
+    ]
+    result = subprocess.run(
+        cmd, capture_output=True, check=True, encoding="utf8"
+    ).stdout
+    patient_id = result.splitlines()[-1]
+    assert patient_id == str(patient.Patient_ID)
+
+
+def test_duplicate_id_checking():
+    study = StudyDefinition(population=patients.all())
+    # A bit of a hack: overwrite the queries we're going to run with a query which
+    # deliberately returns duplicate values
+    study.backend.queries = [
+        (
+            "dummy_query",
+            """
+            SELECT * FROM (
+              VALUES
+                (1,1),
+                (2,2),
+                (3,3),
+                (1,4)
+            ) t (patient_id, foo)
+            """,
+        )
+    ]
+    with pytest.raises(RuntimeError):
+        study.to_dicts()
+    with pytest.raises(RuntimeError):
+        with tempfile.NamedTemporaryFile(mode="w+") as f:
+            study.to_csv(f.name)
+
+
+def test_sqlcmd_and_odbc_outputs_match():
+    session = make_session()
+    patient = Patient(DateOfBirth="1950-01-01")
+    patient.CodedEvents.append(
+        CodedEvent(CTV3Code="XYZ", NumericValue=50, ConsultationDate="2002-06-01")
+    )
+    session.add(patient)
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.with_these_clinical_events(codelist(["XYZ"], "ctv3"))
+    )
+    with tempfile.NamedTemporaryFile() as input_csv_odbc, tempfile.NamedTemporaryFile() as input_csv_sqlcmd:
+        # windows line endings
+        study.to_csv(input_csv_odbc.name, with_sqlcmd=False)
+        # unix line endings
+        study.to_csv(input_csv_sqlcmd.name, with_sqlcmd=True)
+        assert filecmp.cmp(input_csv_odbc.name, input_csv_sqlcmd.name, shallow=False)
+
+
+def test_column_name_clashes_produce_errors():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            age=patients.age_as_of("2020-01-01"),
+            status=patients.satisfying(
+                "age > 70 AND sex = 'M'",
+                sex=patients.sex(),
+                age=patients.age_as_of("2010-01-01"),
+            ),
+        )
+
+
+def test_recursive_definitions_produce_errors():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            this=patients.satisfying("that = 1"),
+            that=patients.satisfying("this = 1"),
+        )
+
+
+def test_using_expression_in_population_definition():
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                Sex="M",
+                DateOfBirth="1970-01-01",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
+                ],
+            ),
+            Patient(Sex="M", DateOfBirth="1975-01-01"),
+            Patient(
+                Sex="F",
+                DateOfBirth="1980-01-01",
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2000-01-01")
+                ],
+            ),
+            Patient(Sex="F", DateOfBirth="1985-01-01"),
+        ]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.satisfying(
+            "has_foo_code AND sex = 'M'",
+            has_foo_code=patients.with_these_clinical_events(
+                codelist(["foo1"], "ctv3")
+            ),
+            sex=patients.sex(),
+        ),
+        age=patients.age_as_of("2020-01-01"),
+    )
+    results = study.to_dicts()
+    assert results[0].keys() == {"patient_id", "age"}
+    assert [i["age"] for i in results] == ["50"]
+
+
+def test_quote():
+    with pytest.raises(ValueError):
+        quote("foo!")
+    assert quote("2012-02-01") == "'20120201'"
+    assert quote("2012") == "'2012'"
+    assert quote(2012) == "2012"
+    assert quote(0.1) == "0.1"
+    assert quote("foo") == "'foo'"
+
+
+def test_number_of_episodes():
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                CodedEvents=[
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2010-01-01"),
+                    # Throw in some irrelevant events
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-01-02"),
+                    CodedEvent(CTV3Code="mto2", ConsultationDate="2010-01-03"),
+                    # These two should be merged in to the previous event
+                    # because there's not more than 14 days between them
+                    CodedEvent(CTV3Code="foo2", ConsultationDate="2010-01-14"),
+                    CodedEvent(CTV3Code="foo3", ConsultationDate="2010-01-20"),
+                    # This is just outside the limit so should count as another event
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2010-02-04"),
+                    # This shouldn't count because there's an "ignore" event on
+                    # the same day (though at a different time)
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="bar2", ConsultationDate="2012-01-01T16:10:00"),
+                    # This should be another episode
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2015-03-05"),
+                    # This "ignore" event should have no effect because it occurs
+                    # on a different day
+                    CodedEvent(CTV3Code="bar1", ConsultationDate="2015-03-06"),
+                    # This is after the time limit and so shouldn't count
+                    CodedEvent(CTV3Code="foo1", ConsultationDate="2020-02-05"),
+                ]
+            ),
+            # This patient doesn't have any relevant events
+            Patient(
+                CodedEvents=[
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-01-01"),
+                    CodedEvent(CTV3Code="mto2", ConsultationDate="2010-01-14"),
+                    CodedEvent(CTV3Code="mto3", ConsultationDate="2010-01-20"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-02-04"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="mtr2", ConsultationDate="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2015-03-05"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2020-02-05"),
+                ]
+            ),
+        ]
+    )
+    session.commit()
+    foo_codes = codelist(["foo1", "foo2", "foo3"], "ctv3")
+    bar_codes = codelist(["bar1", "bar2"], "ctv3")
+    study = StudyDefinition(
+        population=patients.all(),
+        episode_count=patients.with_these_clinical_events(
+            foo_codes,
+            on_or_before="2020-01-01",
+            ignore_days_where_these_codes_occur=bar_codes,
+            returning="number_of_episodes",
+            episode_defined_as="series of events each <= 14 days apart",
+        ),
+        event_count=patients.with_these_clinical_events(
+            foo_codes,
+            on_or_before="2020-01-01",
+            ignore_days_where_these_codes_occur=bar_codes,
+            returning="number_of_matches_in_period",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["episode_count"] for i in results] == ["3", "0"]
+    assert [i["event_count"] for i in results] == ["5", "0"]
+
+
+def test_number_of_episodes_for_medications():
+    oral_steriod = MedicationDictionary(
+        FullName="Oral Steroid", DMD_ID="ab12", MultilexDrug_ID="1"
+    )
+    other_drug = MedicationDictionary(
+        FullName="Other Drug", DMD_ID="cd34", MultilexDrug_ID="2"
+    )
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                MedicationIssues=[
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-01"
+                    ),
+                    # Throw in some irrelevant prescriptions
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-02"
+                    ),
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                    ),
+                    # These two should be merged in to the previous event
+                    # because there's not more than 14 days between them
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-14"
+                    ),
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-01-20"
+                    ),
+                    # This is just outside the limit so should count as another event
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2010-02-04"
+                    ),
+                    # This shouldn't count because there's an "ignore" event on
+                    # the same day (though at a different time)
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod,
+                        ConsultationDate="2012-01-01T10:45:00",
+                    ),
+                    # This should be another episode
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2015-03-05"
+                    ),
+                    # This is after the time limit and so shouldn't count
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod, ConsultationDate="2020-02-05"
+                    ),
+                ],
+                CodedEvents=[
+                    # This "ignore" event should cause us to skip one of the
+                    # meds issues above
+                    CodedEvent(CTV3Code="bar2", ConsultationDate="2012-01-01T16:10:00"),
+                    # This "ignore" event should have no effect because it
+                    # doesn't occur on the same day as any meds issue
+                    CodedEvent(CTV3Code="bar1", ConsultationDate="2015-03-06"),
+                ],
+            ),
+            # This patient doesn't have any relevant events or prescriptions
+            Patient(
+                MedicationIssues=[
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-02"
+                    ),
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                    ),
+                ],
+                CodedEvents=[
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2010-02-04"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2012-01-01T10:45:00"),
+                    CodedEvent(CTV3Code="mtr2", ConsultationDate="2012-01-01T16:10:00"),
+                    CodedEvent(CTV3Code="mto1", ConsultationDate="2015-03-05"),
+                ],
+            ),
+        ]
+    )
+    session.commit()
+    foo_codes = codelist(["ab12"], "snomed")
+    bar_codes = codelist(["bar1", "bar2"], "ctv3")
+    study = StudyDefinition(
+        population=patients.all(),
+        episode_count=patients.with_these_medications(
+            foo_codes,
+            on_or_before="2020-01-01",
+            ignore_days_where_these_clinical_codes_occur=bar_codes,
+            returning="number_of_episodes",
+            episode_defined_as="series of events each <= 14 days apart",
+        ),
+        event_count=patients.with_these_medications(
+            foo_codes,
+            on_or_before="2020-01-01",
+            ignore_days_where_these_clinical_codes_occur=bar_codes,
+            returning="number_of_matches_in_period",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["episode_count"] for i in results] == ["3", "0"]
+    assert [i["event_count"] for i in results] == ["5", "0"]
+
+
+def test_medications_returning_code_with_ignored_days():
+    oral_steriod = MedicationDictionary(
+        FullName="Oral Steroid", DMD_ID="ab12", MultilexDrug_ID="1"
+    )
+    other_drug = MedicationDictionary(
+        FullName="Other Drug", DMD_ID="cd34", MultilexDrug_ID="2"
+    )
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                MedicationIssues=[
+                    MedicationIssue(
+                        MedicationDictionary=other_drug, ConsultationDate="2010-01-03"
+                    ),
+                    # This shouldn't count because there's an "ignore" event on
+                    # the same day (though at a different time)
+                    MedicationIssue(
+                        MedicationDictionary=oral_steriod,
+                        ConsultationDate="2012-01-01T10:45:00",
+                    ),
+                ],
+                CodedEvents=[
+                    # This "ignore" event should cause us to skip one of the
+                    # meds issues above
+                    CodedEvent(CTV3Code="bar1", ConsultationDate="2012-01-01T16:10:00"),
+                ],
+            ),
+        ]
+    )
+    session.commit()
+    drug_codes = codelist(["ab12", "cd34"], "snomed")
+    annual_review_codes = codelist(["bar1"], "ctv3")
+    study = StudyDefinition(
+        population=patients.all(),
+        most_recent_drug=patients.with_these_medications(
+            drug_codes,
+            ignore_days_where_these_clinical_codes_occur=annual_review_codes,
+            returning="code",
+        ),
+        most_recent_drug_date=patients.date_of(
+            "most_recent_drug", date_format="YYYY-MM-DD"
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["most_recent_drug"] for i in results] == ["cd34"]
+    assert [i["most_recent_drug_date"] for i in results] == ["2010-01-03"]
+
+
+def test_patients_with_tpp_vaccination_record():
+    session = make_session()
+    vaccines = [
+        (1, "Hepatyrix", ["TYPHOID", "HEPATITIS A"]),
+        (2, "Madeva", ["INFLUENZA"]),
+        (3, "Optaflu", ["INFLUENZA"]),
+    ]
+    ids = {}
+    for name_id, name, contents in vaccines:
+        ids[name] = name_id
+        for content in contents:
+            session.add(
+                VaccinationReference(
+                    VaccinationName=name,
+                    VaccinationName_ID=name_id,
+                    VaccinationContent=content,
+                )
+            )
+    session.add_all(
+        [
+            Patient(
+                Vaccinations=[
+                    Vaccination(
+                        VaccinationName_ID=ids["Hepatyrix"],
+                        VaccinationDate="2010-01-01",
+                    ),
+                    Vaccination(
+                        VaccinationName_ID=ids["Optaflu"], VaccinationDate="2014-01-01"
+                    ),
+                ]
+            ),
+            Patient(
+                Vaccinations=[
+                    Vaccination(
+                        VaccinationName_ID=ids["Madeva"], VaccinationDate="2013-01-01"
+                    ),
+                    Vaccination(
+                        VaccinationName_ID=ids["Hepatyrix"],
+                        VaccinationDate="2015-01-01",
+                    ),
+                ]
+            ),
+        ]
+    )
+    session.commit()
+
+    study = StudyDefinition(
+        population=patients.all(),
+        value=patients.with_tpp_vaccination_record(
+            target_disease_matches="TYPHOID", on_or_after="2012-01-01",
+        ),
+        date=patients.date_of("value"),
+    )
+    results = study.to_dicts()
+    assert [i["value"] for i in results] == ["0", "1"]
+    assert [i["date"] for i in results] == ["", "2015"]
+
+    study = StudyDefinition(
+        population=patients.all(),
+        value=patients.with_tpp_vaccination_record(
+            target_disease_matches="INFLUENZA",
+            on_or_after="2012-01-01",
+            find_last_match_in_period=True,
+            returning="date",
+        ),
+    )
+    assert [i["value"] for i in study.to_dicts()] == ["2014", "2013"]
+
+    study = StudyDefinition(
+        population=patients.all(),
+        value=patients.with_tpp_vaccination_record(
+            product_name_matches=["Madeva", "Hepatyrix"],
+            find_first_match_in_period=True,
+            returning="date",
+        ),
+    )
+    assert [i["value"] for i in study.to_dicts()] == ["2010", "2013"]
+
+
+def test_patients_with_gp_consultations():
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                RegistrationHistory=[
+                    RegistrationHistory(StartDate="2014-01-01", EndDate="2020-05-01")
+                ],
+                Appointments=[
+                    # Before period starts
+                    Appointment(
+                        SeenDate="2009-01-01", Status=AppointmentStatus.FINISHED
+                    ),
+                    # After period ends
+                    Appointment(
+                        SeenDate="2020-02-01", Status=AppointmentStatus.FINISHED
+                    ),
+                ],
+            ),
+            Patient(
+                RegistrationHistory=[
+                    RegistrationHistory(StartDate="2001-01-01", EndDate="2016-01-01")
+                ],
+                Appointments=[
+                    Appointment(
+                        SeenDate="2011-01-01", Status=AppointmentStatus.FINISHED
+                    ),
+                    # Should not be counted
+                    Appointment(
+                        SeenDate="2012-01-01", Status=AppointmentStatus.DID_NOT_ATTEND
+                    ),
+                    Appointment(
+                        SeenDate="2013-01-01", Status=AppointmentStatus.FINISHED
+                    ),
+                ],
+            ),
+        ]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        consultation_count=patients.with_gp_consultations(
+            between=["2010-01-01", "2015-01-01"],
+            find_last_match_in_period=True,
+            returning="number_of_matches_in_period",
+        ),
+        latest_consultation_date=patients.date_of(
+            "consultation_count", date_format="YYYY-MM"
+        ),
+        has_history=patients.with_complete_gp_consultation_history_between(
+            "2010-01-01", "2015-01-01"
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["latest_consultation_date"] for x in results] == ["", "2013-01"]
+    assert [x["consultation_count"] for x in results] == ["0", "2"]
+    assert [x["has_history"] for x in results] == ["0", "1"]
+
+
+def test_patients_with_test_result_in_sgss():
+    session = make_session()
+    session.add_all(
+        [
+            Patient(
+                SGSS_Positives=[
+                    SGSS_Positive(Earliest_Specimen_Date="2020-05-15"),
+                    SGSS_Positive(Earliest_Specimen_Date="2020-05-20"),
+                ],
+            ),
+            Patient(
+                SGSS_Negatives=[SGSS_Negative(Earliest_Specimen_Date="2020-04-01")],
+                SGSS_Positives=[SGSS_Positive(Earliest_Specimen_Date="2020-04-20")],
+            ),
+            Patient(
+                SGSS_Negatives=[SGSS_Negative(Earliest_Specimen_Date="2020-04-01")],
+            ),
+            Patient(),
+        ]
+    )
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        positive_covid_test_ever=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2", test_result="positive",
+        ),
+        negative_covid_test_ever=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2", test_result="negative",
+        ),
+        tested_before_may=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2", test_result="any", on_or_before="2020-05-01"
+        ),
+        first_positive_test_date=patients.with_test_result_in_sgss(
+            pathogen="SARS-CoV-2",
+            test_result="positive",
+            find_first_match_in_period=True,
+            returning="date",
+            date_format="YYYY-MM-DD",
+        ),
+    )
+    results = study.to_dicts()
+    assert [x["positive_covid_test_ever"] for x in results] == ["1", "1", "0", "0"]
+    assert [x["negative_covid_test_ever"] for x in results] == ["0", "1", "1", "0"]
+    assert [x["tested_before_may"] for x in results] == ["0", "1", "1", "0"]
+    assert [x["first_positive_test_date"] for x in results] == [
+        "2020-05-15",
+        "2020-04-20",
+        "",
+        "",
+    ]
+
+
+@pytest.mark.parametrize("positive", [True, False])
+def test_patients_with_test_result_in_sgss_raises_error_on_bad_data(positive):
+    kwargs = dict(
+        Earliest_Specimen_Date="2020-05-15", Organism_Species_Name="unexpected"
+    )
+    if positive:
+        patient = Patient(SGSS_Positives=[SGSS_Positive(**kwargs)])
+    else:
+        patient = Patient(SGSS_Negatives=[SGSS_Negative(**kwargs)])
+    session = make_session()
+    session.add(patient)
+    session.commit()
+    study = StudyDefinition(
+        population=patients.all(),
+        covid_test=patients.with_test_result_in_sgss(pathogen="SARS-CoV-2",),
+    )
+    with pytest.raises(Exception):
+        study.to_dicts()

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -3,7 +3,7 @@ import time
 
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, DateTime, Float, NVARCHAR, Boolean, Date
+from sqlalchemy import Column, Integer, String, DateTime, Float, NVARCHAR, Date
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import relationship


### PR DESCRIPTION
Original text by @inglesp 

--------

Here's a draft PR that brings our ACME backend closer to something that can run against ACME's data lake.

I've removed all the covariate functions apart from those used in the risk factors research, and I've marked all test tables that do not match the ACME data lake.  Other test tables do now (more-or-less, see below) match the column names and types in the ACME data lake.

The following covariate functions require ACME to add data to the lake, and as far as I know, this has not happened yet:

* `registered_practice_as_of`, for STP and Region
* `address_as_of`, for IMD and rural/urban
* `admitted_to_icu`
* `with_these_codes_on_death_certificate`
* `died_from_any_cause` 
* `with_death_recorded_in_cpns`

There are some TODOs:

* In the ACME data lake, columns containing SNOMED concept IDs have type `BigInteger`, but our existing machinery expects codes to be strings, and this PR does not change that.  SNOMED IDs are opaque and could be treated as strings.  There are several options:
  * Ask ACME to change the SQL for the materialised views we use, and cast to strings there
  * Create our own materialised views (we may want to do that anyway, for performance -- but this then means we're responsible for updating them)
  * Fix the code, which will mean surgery to eg [`_type_from_return_value`](https://github.com/ebmdatalab/opensafely-research-template/blob/master/datalab_cohorts/process_covariate_definitions.py#L312)
* Some medications don't have SNOMED codes.  I hadn't spotted that until this afternoon, and we'll need to discuss this.
* We need to identify SNOMED codes for BMI