### PR TITLE
Only build package/image on push/merge to master

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -1,6 +1,8 @@
 name: Tag repo; build and publish assets
 on:
   push:
+    branches:
+      - master
 
 jobs:
   tag-new-version:


### PR DESCRIPTION
Fixes #168

The downside to this is that it makes testing docker images a bit fiddly but I think this is the way round that creates least confusing.

Testing a docker image can still happen by building it from the command line.