### PR TITLE
Fix SNOMED code column type

### DIFF
--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -199,7 +199,7 @@ class ACMEBackend:
         self._current_column_name = None
         return return_value
 
-    def create_codelist_table(self, codelist, case_sensitive=True):
+    def create_codelist_table(self, codelist):
         table_number = len(self.codelist_tables) + 1
         # We include the current column name for ease of debugging
         column_name = self._current_column_name or "unknown"
@@ -464,11 +464,7 @@ class ACMEBackend:
             # Remove unhandled arguments and check they are unused
             assert not kwargs.pop("episode_defined_as", None)
             return self._patients_with_events(
-                "medication",
-                "",
-                '"snomed-concept-id"',
-                codes_are_case_sensitive=False,
-                **kwargs,
+                "medication", "", '"snomed-concept-id"', **kwargs,
             )
 
     def patients_with_these_clinical_events(self, **kwargs):
@@ -488,11 +484,7 @@ class ACMEBackend:
         else:
             assert not kwargs.pop("episode_defined_as", None)
             return self._patients_with_events(
-                "observation",
-                "",
-                '"snomed-concept-id"',
-                codes_are_case_sensitive=True,
-                **kwargs,
+                "observation", "", '"snomed-concept-id"', **kwargs,
             )
 
     def _patients_with_events(
@@ -500,7 +492,6 @@ class ACMEBackend:
         from_table,
         additional_join,
         code_column,
-        codes_are_case_sensitive,
         codelist,
         # Allows us to say: find codes A and B, but only on days where X and Y
         # didn't happen
@@ -514,7 +505,7 @@ class ACMEBackend:
         returning="binary_flag",
         include_date_of_match=False,
     ):
-        codelist_table = self.create_codelist_table(codelist, codes_are_case_sensitive)
+        codelist_table = self.create_codelist_table(codelist)
         date_condition = make_date_filter('"effective-date"', between)
         not_an_ignored_day_condition = self._none_of_these_codes_occur_on_same_day(
             from_table, ignore_days_where_these_codes_occur
@@ -608,7 +599,7 @@ class ACMEBackend:
         ignore_days_where_these_codes_occur=None,
         episode_defined_as=None,
     ):
-        codelist_table = self.create_codelist_table(codelist, case_sensitive=False)
+        codelist_table = self.create_codelist_table(codelist)
         date_condition = make_date_filter('"effective-date"', between)
         not_an_ignored_day_condition = self._none_of_these_codes_occur_on_same_day(
             "medication", ignore_days_where_these_codes_occur
@@ -658,7 +649,7 @@ class ACMEBackend:
         ignore_days_where_these_codes_occur=None,
         episode_defined_as=None,
     ):
-        codelist_table = self.create_codelist_table(codelist, case_sensitive=True)
+        codelist_table = self.create_codelist_table(codelist)
         date_condition = make_date_filter('"effective-date"', between)
         not_an_ignored_day_condition = self._none_of_these_codes_occur_on_same_day(
             "observation", ignore_days_where_these_codes_occur
@@ -712,7 +703,7 @@ class ACMEBackend:
         """
         if codelist is None:
             return "1 = 1"
-        codelist_table = self.create_codelist_table(codelist, case_sensitive=True)
+        codelist_table = self.create_codelist_table(codelist)
         return f"""
         NOT EXISTS (
           SELECT * FROM observation AS sameday

--- a/datalab_cohorts/acme_backend.py
+++ b/datalab_cohorts/acme_backend.py
@@ -303,17 +303,15 @@ class ACMEBackend:
         # is >=16, weight must be within the last 10 years
         date_condition = make_date_filter('"effective-date"', between)
 
-        # TODO Change these to SNOMED codes
-        bmi_code = "22K.."
-        # XXX these two sets of codes need validating. The final in
-        # each list is the canonical version according to TPP
+        # TODO these codes need validating
+        bmi_code = 301331008  #  Finding of body mass index (finding)
         weight_codes = [
-            "X76C7",  # Concept containing "body weight" terms:
-            "22A..",  # O/E weight
+            27113001,  # Body weight (observable entity)
+            162763007,  # On examination - weight(finding)
         ]
         height_codes = [
-            "XM01E",  # Concept containing height/length/stature/growth terms:
-            "229..",  # O/E height
+            271603002,  # Height / growth measure (observable entity)
+            162755006,  # On examination - height (finding)
         ]
 
         bmi_cte = f"""

--- a/datalab_cohorts/patients.py
+++ b/datalab_cohorts/patients.py
@@ -128,7 +128,6 @@ def mean_recorded_value(
     include_month=False,
     include_day=False,
 ):
-    assert codelist.system == "ctv3"
     return "mean_recorded_value", locals()
 
 

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -20,7 +20,16 @@ import time
 
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, String, DateTime, Float, NVARCHAR, Date
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Float,
+    NVARCHAR,
+    Date,
+    BigInteger,
+)
 from sqlalchemy import ForeignKey
 from sqlalchemy import Table, MetaData
 from sqlalchemy.orm import sessionmaker
@@ -71,23 +80,21 @@ def make_database():
 # Table definitions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# WARNING: This table does not quite correspond to a table in the ACME database!
 medication = Table(
     "medication",
     metadata,
     Column("id", Integer, primary_key=True),
     Column("registration-id", Integer, ForeignKey("patient.id")),
-    Column("snomed-concept-id", String),  # TODO this is a BigInt in the ACME backend
+    Column("snomed-concept-id", BigInteger),
     Column("effective-date", DateTime),
 )
 
-# WARNING: This table does not quite correspond to a table in the ACME database!
 observation = Table(
     "observation",
     metadata,
     Column("id", Integer, primary_key=True),
     Column("registration-id", Integer, ForeignKey("patient.id")),
-    Column("snomed-concept-id", String),  # TODO this is a BigInt in the ACME backend
+    Column("snomed-concept-id", BigInteger),
     Column("value-pq-1", Float),
     Column("effective-date", DateTime),
 )

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -160,13 +160,13 @@ def _make_clinical_events_selection(condition_code, patient_dates=None):
 
 
 def test_clinical_event_without_filters():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(condition_code)
     # No date criteria
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3")
+            codelist([condition_code], "snomedct")
         ),
     )
     results = study.to_dicts()
@@ -174,12 +174,12 @@ def test_clinical_event_without_filters():
 
 
 def test_clinical_event_with_max_date():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(condition_code)
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"), on_or_before="2001-12-01"
+            codelist([condition_code], "snomedct"), on_or_before="2001-12-01"
         ),
     )
     results = study.to_dicts()
@@ -187,12 +187,12 @@ def test_clinical_event_with_max_date():
 
 
 def test_clinical_event_with_min_date():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(condition_code)
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"), on_or_after="2005-12-01"
+            codelist([condition_code], "snomedct"), on_or_after="2005-12-01"
         ),
     )
     results = study.to_dicts()
@@ -200,12 +200,12 @@ def test_clinical_event_with_min_date():
 
 
 def test_clinical_event_with_min_and_max_date():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(condition_code)
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"), between=["2001-12-01", "2002-06-01"]
+            codelist([condition_code], "snomedct"), between=["2001-12-01", "2002-06-01"]
         ),
     )
     results = study.to_dicts()
@@ -213,7 +213,7 @@ def test_clinical_event_with_min_and_max_date():
 
 
 def test_clinical_event_returning_first_date():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -226,7 +226,7 @@ def test_clinical_event_returning_first_date():
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             between=["2001-12-01", "2002-06-01"],
             returning="date",
             find_first_match_in_period=True,
@@ -238,7 +238,7 @@ def test_clinical_event_returning_first_date():
 
 
 def test_clinical_event_returning_last_date():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -251,7 +251,7 @@ def test_clinical_event_returning_last_date():
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             between=["2001-12-01", "2002-06-01"],
             returning="date",
             find_last_match_in_period=True,
@@ -263,13 +263,13 @@ def test_clinical_event_returning_last_date():
 
 
 def test_clinical_event_returning_year_only():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(condition_code)
     # No date criteria
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             returning="date",
             find_first_match_in_period=True,
         ),
@@ -279,13 +279,13 @@ def test_clinical_event_returning_year_only():
 
 
 def test_clinical_event_returning_year_and_month_only():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(condition_code)
     # No date criteria
     study = StudyDefinition(
         population=patients.all(),
         asthma_condition=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             returning="date",
             find_first_match_in_period=True,
             date_format="YYYY-MM",
@@ -296,7 +296,7 @@ def test_clinical_event_returning_year_and_month_only():
 
 
 def test_clinical_event_with_count():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -309,7 +309,7 @@ def test_clinical_event_with_count():
     study = StudyDefinition(
         population=patients.all(),
         asthma_count=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             between=["2001-12-01", "2002-06-01"],
             returning="number_of_matches_in_period",
             find_first_match_in_period=True,
@@ -322,7 +322,7 @@ def test_clinical_event_with_count():
 
 
 def test_clinical_event_with_code():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -335,7 +335,7 @@ def test_clinical_event_with_code():
     study = StudyDefinition(
         population=patients.all(),
         latest_asthma_code=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             between=["2001-12-01", "2002-06-01"],
             returning="code",
             find_last_match_in_period=True,
@@ -345,12 +345,12 @@ def test_clinical_event_with_code():
         ),
     )
     results = study.to_dicts()
-    assert [x["latest_asthma_code"] for x in results] == ["", condition_code, ""]
+    assert [x["latest_asthma_code"] for x in results] == ["", str(condition_code), ""]
     assert [x["latest_asthma_code_date"] for x in results] == ["", "2002-06", ""]
 
 
 def test_clinical_event_with_numeric_value():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -368,7 +368,7 @@ def test_clinical_event_with_numeric_value():
     study = StudyDefinition(
         population=patients.all(),
         asthma_value=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3"),
+            codelist([condition_code], "snomedct"),
             between=["2001-12-01", "2002-06-01"],
             returning="numeric_value",
             find_first_match_in_period=True,
@@ -387,19 +387,23 @@ def test_clinical_event_with_category():
             Patient(),
             Patient(
                 observations=[
-                    Observation(snomed_concept_id="foo1", effective_date="2018-01-01"),
-                    Observation(snomed_concept_id="foo2", effective_date="2020-01-01"),
+                    Observation(
+                        snomed_concept_id=10000001, effective_date="2018-01-01"
+                    ),
+                    Observation(
+                        snomed_concept_id=10000002, effective_date="2020-01-01"
+                    ),
                 ]
             ),
             Patient(
                 observations=[
-                    Observation(snomed_concept_id="foo3", effective_date="2019-01-01")
+                    Observation(snomed_concept_id=10000003, effective_date="2019-01-01")
                 ]
             ),
         ]
     )
     session.commit()
-    codes = codelist([("foo1", "A"), ("foo2", "B"), ("foo3", "C")], "ctv3")
+    codes = codelist([(10000001, "A"), (10000002, "B"), (10000003, "C")], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         code_category=patients.with_these_clinical_events(
@@ -697,7 +701,7 @@ def test_bmi_when_only_some_measurements_of_child():
 
 
 def test_mean_recorded_value():
-    code = "2469."
+    code = 10000001
     session = make_session()
     patient = Patient()
     values = [
@@ -721,7 +725,7 @@ def test_mean_recorded_value():
     study = StudyDefinition(
         population=patients.all(),
         bp_systolic=patients.mean_recorded_value(
-            codelist([code], system="ctv3"),
+            codelist([code], system="snomedct"),
             on_most_recent_day_of_measurement=True,
             between=["2018-01-01", "2020-03-01"],
         ),
@@ -735,7 +739,7 @@ def test_mean_recorded_value():
 
 
 def test_patients_satisfying():
-    condition_code = "ASTHMA"
+    condition_code = 195967001
     session = make_session()
     patient_1 = Patient(date_of_birth="1940-01-01", gender=1)
     patient_2 = Patient(date_of_birth="1940-01-01", gender=2)
@@ -751,7 +755,7 @@ def test_patients_satisfying():
         sex=patients.sex(),
         age=patients.age_as_of("2020-01-01"),
         has_asthma=patients.with_these_clinical_events(
-            codelist([condition_code], "ctv3")
+            codelist([condition_code], "snomedct")
         ),
         at_risk=patients.satisfying("(age > 70 AND sex = 'M') OR has_asthma"),
     )
@@ -760,8 +764,8 @@ def test_patients_satisfying():
 
 
 def test_patients_satisfying_with_hidden_columns():
-    condition_code = "ASTHMA"
-    condition_code2 = "COPD"
+    condition_code = 195967001
+    condition_code2 = 13645005
     session = make_session()
     patient_1 = Patient(date_of_birth="1940-01-01", gender=1)
     patient_2 = Patient(date_of_birth="1940-01-01", gender=2)
@@ -790,10 +794,10 @@ def test_patients_satisfying_with_hidden_columns():
             (has_asthma AND NOT copd)
             """,
             has_asthma=patients.with_these_clinical_events(
-                codelist([condition_code], "ctv3")
+                codelist([condition_code], "snomedct")
             ),
             copd=patients.with_these_clinical_events(
-                codelist([condition_code2], "ctv3")
+                codelist([condition_code2], "snomedct")
             ),
         ),
     )
@@ -809,39 +813,47 @@ def test_patients_categorised_as():
             Patient(
                 gender=1,
                 observations=[
-                    Observation(snomed_concept_id="foo1", effective_date="2000-01-01")
+                    Observation(snomed_concept_id=10000001, effective_date="2000-01-01")
                 ],
             ),
             Patient(
                 gender=2,
                 observations=[
-                    Observation(snomed_concept_id="foo2", effective_date="2000-01-01"),
-                    Observation(snomed_concept_id="bar1", effective_date="2000-01-01"),
+                    Observation(
+                        snomed_concept_id=10000002, effective_date="2000-01-01"
+                    ),
+                    Observation(
+                        snomed_concept_id=20000001, effective_date="2000-01-01"
+                    ),
                 ],
             ),
             Patient(
                 gender=1,
                 observations=[
-                    Observation(snomed_concept_id="foo2", effective_date="2000-01-01")
+                    Observation(snomed_concept_id=10000002, effective_date="2000-01-01")
                 ],
             ),
             Patient(
                 gender=2,
                 observations=[
-                    Observation(snomed_concept_id="foo3", effective_date="2000-01-01")
+                    Observation(snomed_concept_id=10000003, effective_date="2000-01-01")
                 ],
             ),
             Patient(
                 gender=2,
                 observations=[
-                    Observation(snomed_concept_id="bar1", effective_date="2000-01-01"),
+                    Observation(
+                        snomed_concept_id=20000001, effective_date="2000-01-01"
+                    ),
                 ],
             ),
         ]
     )
     session.commit()
-    foo_codes = codelist([("foo1", "A"), ("foo2", "B"), ("foo3", "C")], "ctv3")
-    bar_codes = codelist(["bar1"], "ctv3")
+    foo_codes = codelist(
+        [(10000001, "A"), (10000002, "B"), (10000003, "C")], "snomedct"
+    )
+    bar_codes = codelist([20000001], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         category=patients.categorised_as(
@@ -1298,7 +1310,7 @@ def test_using_expression_in_population_definition():
                 gender=1,
                 date_of_birth="1970-01-01",
                 observations=[
-                    Observation(snomed_concept_id="foo1", effective_date="2000-01-01")
+                    Observation(snomed_concept_id=10000001, effective_date="2000-01-01")
                 ],
             ),
             Patient(gender=1, date_of_birth="1975-01-01"),
@@ -1306,7 +1318,7 @@ def test_using_expression_in_population_definition():
                 gender=2,
                 date_of_birth="1980-01-01",
                 observations=[
-                    Observation(snomed_concept_id="foo1", effective_date="2000-01-01")
+                    Observation(snomed_concept_id=10000001, effective_date="2000-01-01")
                 ],
             ),
             Patient(gender=2, date_of_birth="1985-01-01"),
@@ -1317,7 +1329,7 @@ def test_using_expression_in_population_definition():
         population=patients.satisfying(
             "has_foo_code AND sex = 'M'",
             has_foo_code=patients.with_these_clinical_events(
-                codelist(["foo1"], "ctv3")
+                codelist([10000001], "snomedct")
             ),
             sex=patients.sex(),
         ),
@@ -1344,55 +1356,85 @@ def test_number_of_episodes():
         [
             Patient(
                 observations=[
-                    Observation(snomed_concept_id="foo1", effective_date="2010-01-01"),
+                    Observation(
+                        snomed_concept_id=10000001, effective_date="2010-01-01"
+                    ),
                     # Throw in some irrelevant events
-                    Observation(snomed_concept_id="mto1", effective_date="2010-01-02"),
-                    Observation(snomed_concept_id="mto2", effective_date="2010-01-03"),
+                    Observation(
+                        snomed_concept_id=40000001, effective_date="2010-01-02"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000002, effective_date="2010-01-03"
+                    ),
                     # These two should be merged in to the previous event
                     # because there's not more than 14 days between them
-                    Observation(snomed_concept_id="foo2", effective_date="2010-01-14"),
-                    Observation(snomed_concept_id="foo3", effective_date="2010-01-20"),
+                    Observation(
+                        snomed_concept_id=10000002, effective_date="2010-01-14"
+                    ),
+                    Observation(
+                        snomed_concept_id=10000003, effective_date="2010-01-20"
+                    ),
                     # This is just outside the limit so should count as another event
-                    Observation(snomed_concept_id="foo1", effective_date="2010-02-04"),
+                    Observation(
+                        snomed_concept_id=10000001, effective_date="2010-02-04"
+                    ),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     Observation(
-                        snomed_concept_id="foo1", effective_date="2012-01-01T10:45:00"
+                        snomed_concept_id=10000001, effective_date="2012-01-01T10:45:00"
                     ),
                     Observation(
-                        snomed_concept_id="bar2", effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id=20000002, effective_date="2012-01-01T16:10:00"
                     ),
                     # This should be another episode
-                    Observation(snomed_concept_id="foo1", effective_date="2015-03-05"),
+                    Observation(
+                        snomed_concept_id=10000001, effective_date="2015-03-05"
+                    ),
                     # This "ignore" event should have no effect because it occurs
                     # on a different day
-                    Observation(snomed_concept_id="bar1", effective_date="2015-03-06"),
+                    Observation(
+                        snomed_concept_id=20000001, effective_date="2015-03-06"
+                    ),
                     # This is after the time limit and so shouldn't count
-                    Observation(snomed_concept_id="foo1", effective_date="2020-02-05"),
+                    Observation(
+                        snomed_concept_id=10000001, effective_date="2020-02-05"
+                    ),
                 ]
             ),
             # This patient doesn't have any relevant events
             Patient(
                 observations=[
-                    Observation(snomed_concept_id="mto1", effective_date="2010-01-01"),
-                    Observation(snomed_concept_id="mto2", effective_date="2010-01-14"),
-                    Observation(snomed_concept_id="mto3", effective_date="2010-01-20"),
-                    Observation(snomed_concept_id="mto1", effective_date="2010-02-04"),
                     Observation(
-                        snomed_concept_id="mto1", effective_date="2012-01-01T10:45:00"
+                        snomed_concept_id=40000001, effective_date="2010-01-01"
                     ),
                     Observation(
-                        snomed_concept_id="mtr2", effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id=40000002, effective_date="2010-01-14"
                     ),
-                    Observation(snomed_concept_id="mto1", effective_date="2015-03-05"),
-                    Observation(snomed_concept_id="mto1", effective_date="2020-02-05"),
+                    Observation(
+                        snomed_concept_id=40000003, effective_date="2010-01-20"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000001, effective_date="2010-02-04"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000001, effective_date="2012-01-01T10:45:00"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000004, effective_date="2012-01-01T16:10:00"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000001, effective_date="2015-03-05"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000001, effective_date="2020-02-05"
+                    ),
                 ]
             ),
         ]
     )
     session.commit()
-    foo_codes = codelist(["foo1", "foo2", "foo3"], "ctv3")
-    bar_codes = codelist(["bar1", "bar2"], "ctv3")
+    foo_codes = codelist([10000001, 10000002, 10000003], "snomedct")
+    bar_codes = codelist([20000001, 20000002], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         episode_count=patients.with_these_clinical_events(
@@ -1420,59 +1462,66 @@ def test_number_of_episodes_for_medications():
         [
             Patient(
                 medications=[
-                    Medication(snomed_concept_id="ab12", effective_date="2010-01-01"),
+                    Medication(snomed_concept_id=12121212, effective_date="2010-01-01"),
                     # Throw in some irrelevant prescriptions
-                    Medication(snomed_concept_id="cd34", effective_date="2010-01-02"),
-                    Medication(snomed_concept_id="cd34", effective_date="2010-01-03"),
+                    Medication(snomed_concept_id=34343434, effective_date="2010-01-02"),
+                    Medication(snomed_concept_id=34343434, effective_date="2010-01-03"),
                     # These two should be merged in to the previous event
                     # because there's not more than 14 days between them
-                    Medication(snomed_concept_id="ab12", effective_date="2010-01-14"),
-                    Medication(snomed_concept_id="ab12", effective_date="2010-01-20"),
+                    Medication(snomed_concept_id=12121212, effective_date="2010-01-14"),
+                    Medication(snomed_concept_id=12121212, effective_date="2010-01-20"),
                     # This is just outside the limit so should count as another event
-                    Medication(snomed_concept_id="ab12", effective_date="2010-02-04"),
+                    Medication(snomed_concept_id=12121212, effective_date="2010-02-04"),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     Medication(
-                        snomed_concept_id="ab12", effective_date="2012-01-01T10:45:00",
+                        snomed_concept_id=12121212,
+                        effective_date="2012-01-01T10:45:00",
                     ),
                     # This should be another episode
-                    Medication(snomed_concept_id="ab12", effective_date="2015-03-05"),
+                    Medication(snomed_concept_id=12121212, effective_date="2015-03-05"),
                     # This is after the time limit and so shouldn't count
-                    Medication(snomed_concept_id="ab12", effective_date="2020-02-05"),
+                    Medication(snomed_concept_id=12121212, effective_date="2020-02-05"),
                 ],
                 observations=[
                     # This "ignore" event should cause us to skip one of the
                     # meds issues above
                     Observation(
-                        snomed_concept_id="bar2", effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id=20000002, effective_date="2012-01-01T16:10:00"
                     ),
                     # This "ignore" event should have no effect because it
                     # doesn't occur on the same day as any meds issue
-                    Observation(snomed_concept_id="bar1", effective_date="2015-03-06"),
+                    Observation(
+                        snomed_concept_id=20000001, effective_date="2015-03-06"
+                    ),
                 ],
             ),
             # This patient doesn't have any relevant events or prescriptions
             Patient(
                 medications=[
-                    Medication(snomed_concept_id="cd34", effective_date="2010-01-02"),
-                    Medication(snomed_concept_id="cd34", effective_date="2010-01-03"),
+                    Medication(snomed_concept_id=34343434, effective_date="2010-01-02"),
+                    Medication(snomed_concept_id=34343434, effective_date="2010-01-03"),
                 ],
                 observations=[
-                    Observation(snomed_concept_id="mto1", effective_date="2010-02-04"),
                     Observation(
-                        snomed_concept_id="mto1", effective_date="2012-01-01T10:45:00"
+                        snomed_concept_id=40000001, effective_date="2010-02-04"
                     ),
                     Observation(
-                        snomed_concept_id="mtr2", effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id=40000001, effective_date="2012-01-01T10:45:00"
                     ),
-                    Observation(snomed_concept_id="mto1", effective_date="2015-03-05"),
+                    Observation(
+                        snomed_concept_id=40000004, effective_date="2012-01-01T16:10:00"
+                    ),
+                    Observation(
+                        snomed_concept_id=40000001, effective_date="2015-03-05"
+                    ),
                 ],
             ),
         ]
     )
     session.commit()
-    foo_codes = codelist(["ab12"], "snomed")
-    bar_codes = codelist(["bar1", "bar2"], "ctv3")
+    foo_codes = codelist([12121212], "snomed")
+    bar_codes = codelist([20000001, 20000002], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         episode_count=patients.with_these_medications(
@@ -1500,26 +1549,27 @@ def test_medications_returning_code_with_ignored_days():
         [
             Patient(
                 medications=[
-                    Medication(snomed_concept_id="cd34", effective_date="2010-01-03"),
+                    Medication(snomed_concept_id=34343434, effective_date="2010-01-03"),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     Medication(
-                        snomed_concept_id="ab12", effective_date="2012-01-01T10:45:00",
+                        snomed_concept_id=12121212,
+                        effective_date="2012-01-01T10:45:00",
                     ),
                 ],
                 observations=[
                     # This "ignore" event should cause us to skip one of the
                     # meds issues above
                     Observation(
-                        snomed_concept_id="bar1", effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id=20000001, effective_date="2012-01-01T16:10:00"
                     ),
                 ],
             ),
         ]
     )
     session.commit()
-    drug_codes = codelist(["ab12", "cd34"], "snomed")
-    annual_review_codes = codelist(["bar1"], "ctv3")
+    drug_codes = codelist([12121212, 34343434], "snomed")
+    annual_review_codes = codelist([20000001], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         most_recent_drug=patients.with_these_medications(
@@ -1532,5 +1582,5 @@ def test_medications_returning_code_with_ignored_days():
         ),
     )
     results = study.to_dicts()
-    assert [i["most_recent_drug"] for i in results] == ["cd34"]
+    assert [i["most_recent_drug"] for i in results] == ["34343434"]
     assert [i["most_recent_drug_date"] for i in results] == ["2010-01-03"]

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -443,8 +443,8 @@ def test_patients_registered_with_one_practice_between():
 def test_simple_bmi(include_dates):
     session = make_session()
 
-    weight_code = "X76C7"
-    height_code = "XM01E"
+    weight_code = 27113001
+    height_code = 271603002
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -487,8 +487,8 @@ def test_simple_bmi(include_dates):
 def test_bmi_rounded():
     session = make_session()
 
-    weight_code = "X76C7"
-    height_code = "XM01E"
+    weight_code = 27113001
+    height_code = 271603002
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -519,8 +519,8 @@ def test_bmi_rounded():
 def test_bmi_with_zero_values():
     session = make_session()
 
-    weight_code = "X76C7"
-    height_code = "XM01E"
+    weight_code = 27113001
+    height_code = 271603002
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -551,8 +551,8 @@ def test_bmi_with_zero_values():
 def test_explicit_bmi_fallback():
     session = make_session()
 
-    weight_code = "X76C7"
-    bmi_code = "22K.."
+    weight_code = 27113001
+    bmi_code = 301331008
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -583,7 +583,7 @@ def test_explicit_bmi_fallback():
 def test_no_bmi_when_old_date():
     session = make_session()
 
-    bmi_code = "22K.."
+    bmi_code = 301331008
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -609,7 +609,7 @@ def test_no_bmi_when_old_date():
 def test_no_bmi_when_measurements_of_child():
     session = make_session()
 
-    bmi_code = "22K.."
+    bmi_code = 301331008
 
     patient = Patient(date_of_birth="2000-01-01")
     patient.observations.append(
@@ -635,7 +635,7 @@ def test_no_bmi_when_measurements_of_child():
 def test_no_bmi_when_measurement_after_reference_date():
     session = make_session()
 
-    bmi_code = "22K.."
+    bmi_code = 301331008
 
     patient = Patient(date_of_birth="1900-01-01")
     patient.observations.append(
@@ -661,9 +661,9 @@ def test_no_bmi_when_measurement_after_reference_date():
 def test_bmi_when_only_some_measurements_of_child():
     session = make_session()
 
-    bmi_code = "22K.."
-    weight_code = "X76C7"
-    height_code = "XM01E"
+    bmi_code = 301331008
+    weight_code = 27113001
+    height_code = 271603002
 
     patient = Patient(date_of_birth="1990-01-01")
     patient.observations.append(

--- a/tests/test_acme_backend.py
+++ b/tests/test_acme_backend.py
@@ -160,7 +160,7 @@ def _make_clinical_events_selection(condition_code, patient_dates=None):
 
 
 def test_clinical_event_without_filters():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(condition_code)
     # No date criteria
     study = StudyDefinition(
@@ -174,7 +174,7 @@ def test_clinical_event_without_filters():
 
 
 def test_clinical_event_with_max_date():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(condition_code)
     study = StudyDefinition(
         population=patients.all(),
@@ -187,7 +187,7 @@ def test_clinical_event_with_max_date():
 
 
 def test_clinical_event_with_min_date():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(condition_code)
     study = StudyDefinition(
         population=patients.all(),
@@ -200,7 +200,7 @@ def test_clinical_event_with_min_date():
 
 
 def test_clinical_event_with_min_and_max_date():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(condition_code)
     study = StudyDefinition(
         population=patients.all(),
@@ -213,7 +213,7 @@ def test_clinical_event_with_min_and_max_date():
 
 
 def test_clinical_event_returning_first_date():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -238,7 +238,7 @@ def test_clinical_event_returning_first_date():
 
 
 def test_clinical_event_returning_last_date():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -263,7 +263,7 @@ def test_clinical_event_returning_last_date():
 
 
 def test_clinical_event_returning_year_only():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(condition_code)
     # No date criteria
     study = StudyDefinition(
@@ -279,7 +279,7 @@ def test_clinical_event_returning_year_only():
 
 
 def test_clinical_event_returning_year_and_month_only():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(condition_code)
     # No date criteria
     study = StudyDefinition(
@@ -296,7 +296,7 @@ def test_clinical_event_returning_year_and_month_only():
 
 
 def test_clinical_event_with_count():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -322,7 +322,7 @@ def test_clinical_event_with_count():
 
 
 def test_clinical_event_with_code():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -350,7 +350,7 @@ def test_clinical_event_with_code():
 
 
 def test_clinical_event_with_numeric_value():
-    condition_code = 195967001
+    condition_code = "195967001"
     _make_clinical_events_selection(
         condition_code,
         patient_dates=[
@@ -388,22 +388,26 @@ def test_clinical_event_with_category():
             Patient(
                 observations=[
                     Observation(
-                        snomed_concept_id=10000001, effective_date="2018-01-01"
+                        snomed_concept_id="10000001", effective_date="2018-01-01"
                     ),
                     Observation(
-                        snomed_concept_id=10000002, effective_date="2020-01-01"
+                        snomed_concept_id="10000002", effective_date="2020-01-01"
                     ),
                 ]
             ),
             Patient(
                 observations=[
-                    Observation(snomed_concept_id=10000003, effective_date="2019-01-01")
+                    Observation(
+                        snomed_concept_id="10000003", effective_date="2019-01-01"
+                    )
                 ]
             ),
         ]
     )
     session.commit()
-    codes = codelist([(10000001, "A"), (10000002, "B"), (10000003, "C")], "snomedct")
+    codes = codelist(
+        [("10000001", "A"), ("10000002", "B"), ("10000003", "C")], "snomedct"
+    )
     study = StudyDefinition(
         population=patients.all(),
         code_category=patients.with_these_clinical_events(
@@ -447,8 +451,8 @@ def test_patients_registered_with_one_practice_between():
 def test_simple_bmi(include_dates):
     session = make_session()
 
-    weight_code = 27113001
-    height_code = 271603002
+    weight_code = "27113001"
+    height_code = "271603002"
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -491,8 +495,8 @@ def test_simple_bmi(include_dates):
 def test_bmi_rounded():
     session = make_session()
 
-    weight_code = 27113001
-    height_code = 271603002
+    weight_code = "27113001"
+    height_code = "271603002"
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -523,8 +527,8 @@ def test_bmi_rounded():
 def test_bmi_with_zero_values():
     session = make_session()
 
-    weight_code = 27113001
-    height_code = 271603002
+    weight_code = "27113001"
+    height_code = "271603002"
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -555,8 +559,8 @@ def test_bmi_with_zero_values():
 def test_explicit_bmi_fallback():
     session = make_session()
 
-    weight_code = 27113001
-    bmi_code = 301331008
+    weight_code = "27113001"
+    bmi_code = "301331008"
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -587,7 +591,7 @@ def test_explicit_bmi_fallback():
 def test_no_bmi_when_old_date():
     session = make_session()
 
-    bmi_code = 301331008
+    bmi_code = "301331008"
 
     patient = Patient(date_of_birth="1950-01-01")
     patient.observations.append(
@@ -613,7 +617,7 @@ def test_no_bmi_when_old_date():
 def test_no_bmi_when_measurements_of_child():
     session = make_session()
 
-    bmi_code = 301331008
+    bmi_code = "301331008"
 
     patient = Patient(date_of_birth="2000-01-01")
     patient.observations.append(
@@ -639,7 +643,7 @@ def test_no_bmi_when_measurements_of_child():
 def test_no_bmi_when_measurement_after_reference_date():
     session = make_session()
 
-    bmi_code = 301331008
+    bmi_code = "301331008"
 
     patient = Patient(date_of_birth="1900-01-01")
     patient.observations.append(
@@ -665,9 +669,9 @@ def test_no_bmi_when_measurement_after_reference_date():
 def test_bmi_when_only_some_measurements_of_child():
     session = make_session()
 
-    bmi_code = 301331008
-    weight_code = 27113001
-    height_code = 271603002
+    bmi_code = "301331008"
+    weight_code = "27113001"
+    height_code = "271603002"
 
     patient = Patient(date_of_birth="1990-01-01")
     patient.observations.append(
@@ -701,7 +705,7 @@ def test_bmi_when_only_some_measurements_of_child():
 
 
 def test_mean_recorded_value():
-    code = 10000001
+    code = "10000001"
     session = make_session()
     patient = Patient()
     values = [
@@ -739,7 +743,7 @@ def test_mean_recorded_value():
 
 
 def test_patients_satisfying():
-    condition_code = 195967001
+    condition_code = "195967001"
     session = make_session()
     patient_1 = Patient(date_of_birth="1940-01-01", gender=1)
     patient_2 = Patient(date_of_birth="1940-01-01", gender=2)
@@ -764,8 +768,8 @@ def test_patients_satisfying():
 
 
 def test_patients_satisfying_with_hidden_columns():
-    condition_code = 195967001
-    condition_code2 = 13645005
+    condition_code = "195967001"
+    condition_code2 = "13645005"
     session = make_session()
     patient_1 = Patient(date_of_birth="1940-01-01", gender=1)
     patient_2 = Patient(date_of_birth="1940-01-01", gender=2)
@@ -813,37 +817,43 @@ def test_patients_categorised_as():
             Patient(
                 gender=1,
                 observations=[
-                    Observation(snomed_concept_id=10000001, effective_date="2000-01-01")
+                    Observation(
+                        snomed_concept_id="10000001", effective_date="2000-01-01"
+                    )
                 ],
             ),
             Patient(
                 gender=2,
                 observations=[
                     Observation(
-                        snomed_concept_id=10000002, effective_date="2000-01-01"
+                        snomed_concept_id="10000002", effective_date="2000-01-01"
                     ),
                     Observation(
-                        snomed_concept_id=20000001, effective_date="2000-01-01"
+                        snomed_concept_id="20000001", effective_date="2000-01-01"
                     ),
                 ],
             ),
             Patient(
                 gender=1,
                 observations=[
-                    Observation(snomed_concept_id=10000002, effective_date="2000-01-01")
-                ],
-            ),
-            Patient(
-                gender=2,
-                observations=[
-                    Observation(snomed_concept_id=10000003, effective_date="2000-01-01")
+                    Observation(
+                        snomed_concept_id="10000002", effective_date="2000-01-01"
+                    )
                 ],
             ),
             Patient(
                 gender=2,
                 observations=[
                     Observation(
-                        snomed_concept_id=20000001, effective_date="2000-01-01"
+                        snomed_concept_id="10000003", effective_date="2000-01-01"
+                    )
+                ],
+            ),
+            Patient(
+                gender=2,
+                observations=[
+                    Observation(
+                        snomed_concept_id="20000001", effective_date="2000-01-01"
                     ),
                 ],
             ),
@@ -851,9 +861,9 @@ def test_patients_categorised_as():
     )
     session.commit()
     foo_codes = codelist(
-        [(10000001, "A"), (10000002, "B"), (10000003, "C")], "snomedct"
+        [("10000001", "A"), ("10000002", "B"), ("10000003", "C")], "snomedct"
     )
-    bar_codes = codelist([20000001], "snomedct")
+    bar_codes = codelist(["20000001"], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         category=patients.categorised_as(
@@ -1310,7 +1320,9 @@ def test_using_expression_in_population_definition():
                 gender=1,
                 date_of_birth="1970-01-01",
                 observations=[
-                    Observation(snomed_concept_id=10000001, effective_date="2000-01-01")
+                    Observation(
+                        snomed_concept_id="10000001", effective_date="2000-01-01"
+                    )
                 ],
             ),
             Patient(gender=1, date_of_birth="1975-01-01"),
@@ -1318,7 +1330,9 @@ def test_using_expression_in_population_definition():
                 gender=2,
                 date_of_birth="1980-01-01",
                 observations=[
-                    Observation(snomed_concept_id=10000001, effective_date="2000-01-01")
+                    Observation(
+                        snomed_concept_id="10000001", effective_date="2000-01-01"
+                    )
                 ],
             ),
             Patient(gender=2, date_of_birth="1985-01-01"),
@@ -1329,7 +1343,7 @@ def test_using_expression_in_population_definition():
         population=patients.satisfying(
             "has_foo_code AND sex = 'M'",
             has_foo_code=patients.with_these_clinical_events(
-                codelist([10000001], "snomedct")
+                codelist(["10000001"], "snomedct")
             ),
             sex=patients.sex(),
         ),
@@ -1357,47 +1371,49 @@ def test_number_of_episodes():
             Patient(
                 observations=[
                     Observation(
-                        snomed_concept_id=10000001, effective_date="2010-01-01"
+                        snomed_concept_id="10000001", effective_date="2010-01-01"
                     ),
                     # Throw in some irrelevant events
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2010-01-02"
+                        snomed_concept_id="40000001", effective_date="2010-01-02"
                     ),
                     Observation(
-                        snomed_concept_id=40000002, effective_date="2010-01-03"
+                        snomed_concept_id="40000002", effective_date="2010-01-03"
                     ),
                     # These two should be merged in to the previous event
                     # because there's not more than 14 days between them
                     Observation(
-                        snomed_concept_id=10000002, effective_date="2010-01-14"
+                        snomed_concept_id="10000002", effective_date="2010-01-14"
                     ),
                     Observation(
-                        snomed_concept_id=10000003, effective_date="2010-01-20"
+                        snomed_concept_id="10000003", effective_date="2010-01-20"
                     ),
                     # This is just outside the limit so should count as another event
                     Observation(
-                        snomed_concept_id=10000001, effective_date="2010-02-04"
+                        snomed_concept_id="10000001", effective_date="2010-02-04"
                     ),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     Observation(
-                        snomed_concept_id=10000001, effective_date="2012-01-01T10:45:00"
+                        snomed_concept_id="10000001",
+                        effective_date="2012-01-01T10:45:00",
                     ),
                     Observation(
-                        snomed_concept_id=20000002, effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id="20000002",
+                        effective_date="2012-01-01T16:10:00",
                     ),
                     # This should be another episode
                     Observation(
-                        snomed_concept_id=10000001, effective_date="2015-03-05"
+                        snomed_concept_id="10000001", effective_date="2015-03-05"
                     ),
                     # This "ignore" event should have no effect because it occurs
                     # on a different day
                     Observation(
-                        snomed_concept_id=20000001, effective_date="2015-03-06"
+                        snomed_concept_id="20000001", effective_date="2015-03-06"
                     ),
                     # This is after the time limit and so shouldn't count
                     Observation(
-                        snomed_concept_id=10000001, effective_date="2020-02-05"
+                        snomed_concept_id="10000001", effective_date="2020-02-05"
                     ),
                 ]
             ),
@@ -1405,36 +1421,38 @@ def test_number_of_episodes():
             Patient(
                 observations=[
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2010-01-01"
+                        snomed_concept_id="40000001", effective_date="2010-01-01"
                     ),
                     Observation(
-                        snomed_concept_id=40000002, effective_date="2010-01-14"
+                        snomed_concept_id="40000002", effective_date="2010-01-14"
                     ),
                     Observation(
-                        snomed_concept_id=40000003, effective_date="2010-01-20"
+                        snomed_concept_id="40000003", effective_date="2010-01-20"
                     ),
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2010-02-04"
+                        snomed_concept_id="40000001", effective_date="2010-02-04"
                     ),
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2012-01-01T10:45:00"
+                        snomed_concept_id="40000001",
+                        effective_date="2012-01-01T10:45:00",
                     ),
                     Observation(
-                        snomed_concept_id=40000004, effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id="40000004",
+                        effective_date="2012-01-01T16:10:00",
                     ),
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2015-03-05"
+                        snomed_concept_id="40000001", effective_date="2015-03-05"
                     ),
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2020-02-05"
+                        snomed_concept_id="40000001", effective_date="2020-02-05"
                     ),
                 ]
             ),
         ]
     )
     session.commit()
-    foo_codes = codelist([10000001, 10000002, 10000003], "snomedct")
-    bar_codes = codelist([20000001, 20000002], "snomedct")
+    foo_codes = codelist(["10000001", "10000002", "10000003"], "snomedct")
+    bar_codes = codelist(["20000001", "20000002"], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         episode_count=patients.with_these_clinical_events(
@@ -1462,66 +1480,89 @@ def test_number_of_episodes_for_medications():
         [
             Patient(
                 medications=[
-                    Medication(snomed_concept_id=12121212, effective_date="2010-01-01"),
+                    Medication(
+                        snomed_concept_id="12121212", effective_date="2010-01-01"
+                    ),
                     # Throw in some irrelevant prescriptions
-                    Medication(snomed_concept_id=34343434, effective_date="2010-01-02"),
-                    Medication(snomed_concept_id=34343434, effective_date="2010-01-03"),
+                    Medication(
+                        snomed_concept_id="34343434", effective_date="2010-01-02"
+                    ),
+                    Medication(
+                        snomed_concept_id="34343434", effective_date="2010-01-03"
+                    ),
                     # These two should be merged in to the previous event
                     # because there's not more than 14 days between them
-                    Medication(snomed_concept_id=12121212, effective_date="2010-01-14"),
-                    Medication(snomed_concept_id=12121212, effective_date="2010-01-20"),
+                    Medication(
+                        snomed_concept_id="12121212", effective_date="2010-01-14"
+                    ),
+                    Medication(
+                        snomed_concept_id="12121212", effective_date="2010-01-20"
+                    ),
                     # This is just outside the limit so should count as another event
-                    Medication(snomed_concept_id=12121212, effective_date="2010-02-04"),
+                    Medication(
+                        snomed_concept_id="12121212", effective_date="2010-02-04"
+                    ),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     Medication(
-                        snomed_concept_id=12121212,
+                        snomed_concept_id="12121212",
                         effective_date="2012-01-01T10:45:00",
                     ),
                     # This should be another episode
-                    Medication(snomed_concept_id=12121212, effective_date="2015-03-05"),
+                    Medication(
+                        snomed_concept_id="12121212", effective_date="2015-03-05"
+                    ),
                     # This is after the time limit and so shouldn't count
-                    Medication(snomed_concept_id=12121212, effective_date="2020-02-05"),
+                    Medication(
+                        snomed_concept_id="12121212", effective_date="2020-02-05"
+                    ),
                 ],
                 observations=[
                     # This "ignore" event should cause us to skip one of the
                     # meds issues above
                     Observation(
-                        snomed_concept_id=20000002, effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id="20000002",
+                        effective_date="2012-01-01T16:10:00",
                     ),
                     # This "ignore" event should have no effect because it
                     # doesn't occur on the same day as any meds issue
                     Observation(
-                        snomed_concept_id=20000001, effective_date="2015-03-06"
+                        snomed_concept_id="20000001", effective_date="2015-03-06"
                     ),
                 ],
             ),
             # This patient doesn't have any relevant events or prescriptions
             Patient(
                 medications=[
-                    Medication(snomed_concept_id=34343434, effective_date="2010-01-02"),
-                    Medication(snomed_concept_id=34343434, effective_date="2010-01-03"),
+                    Medication(
+                        snomed_concept_id="34343434", effective_date="2010-01-02"
+                    ),
+                    Medication(
+                        snomed_concept_id="34343434", effective_date="2010-01-03"
+                    ),
                 ],
                 observations=[
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2010-02-04"
+                        snomed_concept_id="40000001", effective_date="2010-02-04"
                     ),
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2012-01-01T10:45:00"
+                        snomed_concept_id="40000001",
+                        effective_date="2012-01-01T10:45:00",
                     ),
                     Observation(
-                        snomed_concept_id=40000004, effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id="40000004",
+                        effective_date="2012-01-01T16:10:00",
                     ),
                     Observation(
-                        snomed_concept_id=40000001, effective_date="2015-03-05"
+                        snomed_concept_id="40000001", effective_date="2015-03-05"
                     ),
                 ],
             ),
         ]
     )
     session.commit()
-    foo_codes = codelist([12121212], "snomed")
-    bar_codes = codelist([20000001, 20000002], "snomedct")
+    foo_codes = codelist(["12121212"], "snomed")
+    bar_codes = codelist(["20000001", "20000002"], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         episode_count=patients.with_these_medications(
@@ -1549,11 +1590,13 @@ def test_medications_returning_code_with_ignored_days():
         [
             Patient(
                 medications=[
-                    Medication(snomed_concept_id=34343434, effective_date="2010-01-03"),
+                    Medication(
+                        snomed_concept_id="34343434", effective_date="2010-01-03"
+                    ),
                     # This shouldn't count because there's an "ignore" event on
                     # the same day (though at a different time)
                     Medication(
-                        snomed_concept_id=12121212,
+                        snomed_concept_id="12121212",
                         effective_date="2012-01-01T10:45:00",
                     ),
                 ],
@@ -1561,15 +1604,16 @@ def test_medications_returning_code_with_ignored_days():
                     # This "ignore" event should cause us to skip one of the
                     # meds issues above
                     Observation(
-                        snomed_concept_id=20000001, effective_date="2012-01-01T16:10:00"
+                        snomed_concept_id="20000001",
+                        effective_date="2012-01-01T16:10:00",
                     ),
                 ],
             ),
         ]
     )
     session.commit()
-    drug_codes = codelist([12121212, 34343434], "snomed")
-    annual_review_codes = codelist([20000001], "snomedct")
+    drug_codes = codelist(["12121212", "34343434"], "snomed")
+    annual_review_codes = codelist(["20000001"], "snomedct")
     study = StudyDefinition(
         population=patients.all(),
         most_recent_drug=patients.with_these_medications(


### PR DESCRIPTION
With a tiny bit of special-casing in `get_column_expression`, this turns out not to be that much of a change.