### PR TITLE
Test that we can build PyPI package successfully

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -23,7 +23,7 @@ jobs:
 
   build-and-publish-package:
     runs-on: ubuntu-latest
-    name: Build and publish docker image
+    name: Build and publish PyPI package
     # Only on a tagged release
     needs: tag-new-version
     if: needs.tag-new-version.outputs.tag

--- a/.github/workflows/test_runner.yaml
+++ b/.github/workflows/test_runner.yaml
@@ -49,3 +49,19 @@ jobs:
       run: cohortextractor generate_cohort --expectations-population=10000
     - name: Run model
       run: docker run --mount source=${{ github.workspace }},dst=/workspace,type=bind docker.pkg.github.com/opensafely/stata-docker/stata-mp analysis/model.do
+  test-package-build:
+    runs-on: ubuntu-latest
+    name: Test we can build PyPI package
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install wheel package
+      run: |
+        pip install wheel
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel


### PR DESCRIPTION
This would have caught the issue with importing the library inside
setup.py earlier.

There's probably a clever way we could use the output of this build step
in the publish step so we avoid a bit of duplicated code and wasted
work, but this will do for now.