### PR TITLE
Fix flaky Presto tests

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -35,7 +35,7 @@ exec docker-compose run \
   --volume "$PWD:/workspace" \
   -e PYENV_VERSION=3.7.8 \
   -e TPP_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_OpenCorona' \
-  -e EMIS_DATABASE_URL=presto://presto:8080/mssql/dbo \
-  -e EMIS_DATASOURCE_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_EMIS' \
+  -e ACME_DATABASE_URL=presto://presto:8080/mssql/dbo \
+  -e ACME_DATASOURCE_DATABASE_URL='mssql://SA:Your_password123!@mssql:1433/Test_ACME' \
   app \
     --login -- "$@"

--- a/tests/acme_backend_setup.py
+++ b/tests/acme_backend_setup.py
@@ -60,7 +60,17 @@ def make_engine():
                 time.sleep(1)
             else:
                 raise
-    wait_for_presto_to_be_ready(os.environ["ACME_DATABASE_URL"], timeout)
+    wait_for_presto_to_be_ready(
+        os.environ["ACME_DATABASE_URL"],
+        # Presto will show active nodes in its `system.runtime.nodes` table but
+        # then throw a "no nodes available" error if you try to execute a query
+        # which needs to touch the MSSQL instance. So to properly confirm that
+        # Presto is ready we need a query which forces it to connect to MSSQL,
+        # but ideally one which doesn't depend on any particular configuration
+        # having been done first. The below seems to do the trick.
+        "SELECT 1 FROM sys.tables",
+        timeout,
+    )
     return engine
 
 


### PR DESCRIPTION
It turns out that Presto will tell you it has active nodes in its `system.runtime.nodes` table but still throw a "no nodes available" error if you try to execute a query which needs to touch the MSSQL instance. This PR works around that issue.

Closes #197