### PR TITLE
feat: Support returning de-registrations dates

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -569,3 +569,15 @@ def attended_emergency_care(
     See https://github.com/opensafely/cohort-extractor/issues/182 for discussoin.
     """
     return "attended_emergency_care", locals()
+
+
+def date_deregistered_from_all_supported_practices(
+    on_or_before=None, on_or_after=None, between=None, date_format=None,
+):
+    """
+    Returns the date (if any) on which the patient de-registered from all
+    practices for which OpenSAFELY has data. Events which occur in primary care
+    after this date will not be recorded in the platform (though there may be
+    data from other sources e.g. SGSS, CPNS).
+    """
+    return "date_deregistered_from_all_supported_practices", locals()

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -265,6 +265,9 @@ class GetColumnType:
     def type_of_with_complete_history_between(self, **kwargs):
         return "bool"
 
+    def type_of_date_deregistered_from_all_supported_practices(self, **kwargs):
+        return "date"
+
     def type_of_with_these_medications(self, returning, **kwargs):
         return self._type_from_return_value(returning)
 

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -848,6 +848,36 @@ class TPPBackend:
             """,
         )
 
+    def patients_date_deregistered_from_all_supported_practices(self, between):
+        if between is None:
+            between = (None, None)
+        min_date, max_date = between
+        # Registrations with no end date are recorded using an end date of
+        # 9999-12-31, so if no max date is supplied then we need to set a max
+        # date to something less than 9999-12-31 to filter out registrations
+        # which have no end date.
+        if max_date is None:
+            max_date = "3000-01-01"
+        if min_date is None:
+            min_date = "1900-01-01"
+        return (
+            ["patient_id", "date"],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              CASE
+                WHEN
+                  MAX(EndDate) BETWEEN {quote(min_date)} AND {quote(max_date)}
+                THEN
+                  MAX(EndDate)
+              END AS date
+            FROM
+              RegistrationHistory
+            GROUP BY
+              Patient_ID
+            """,
+        )
+
     def patients_address_as_of(self, date, returning=None, round_to_nearest=None):
         # N.B. A value of -1 indicates no postcode recorded on the
         # record, an invalid postcode, or no fixed abode.


### PR DESCRIPTION
Normally we require that patients stay registered throughout the study
period, but in certain cases where we have data from outside primary
care we may want to include de-registered patients in a study. For such
patients we need to know the date they de-registered so we can treat
them appropriately in the analysis.