### PR TITLE
fix: Refactor sqlcmd wrapper for better error handling

### DIFF
--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import tempfile
 from urllib.parse import urlparse, unquote
@@ -105,7 +106,13 @@ def _mssql_query_to_csv_file(database_url, query, filename):
                 # sqlcmd outputs a separator line (consisting of repeated
                 # dashes) between the column headers and the data. There's no
                 # option to disable this behaviour so we remove it here.
-                if line_num == 1 and line.startswith("-"):
+                if line_num == 1:
+                    if not re.match(r"^[\-,]+$", line):
+                        stderr += (
+                            f"\nExpected line 2 to be a separator containing only "
+                            f"dashes and commas but found: {line}"
+                        )
+                        has_error = True
                     continue
                 yield line
                 out.write(line)

--- a/tests/test_mssql_utils.py
+++ b/tests/test_mssql_utils.py
@@ -1,6 +1,8 @@
 import os
 from cohortextractor.mssql_utils import mssql_query_to_csv_file
 
+import pytest
+
 
 def test_mssql_query_to_csv_file_does_not_append(tmp_path):
     with open(tmp_path / "output.csv", "w") as f:
@@ -13,3 +15,22 @@ def test_mssql_query_to_csv_file_does_not_append(tmp_path):
     with open(tmp_path / "output.csv", "r") as f:
         contents = f.read().strip()
     assert contents == "hello,value\ntest_output,1"
+
+
+def test_late_errors_are_caught(tmp_path):
+    query = """
+    CREATE TABLE #test (n INTEGER)
+    GO
+    INSERT INTO #test VALUES (1), (2), (3), (4), (5)
+    GO
+    SELECT 1000 / (n - 5) AS value FROM #test ORDER BY n
+    """
+    with pytest.raises(ValueError) as excinfo:
+        mssql_query_to_csv_file(
+            os.environ["TPP_DATABASE_URL"], query, tmp_path / "output.csv",
+        )
+    assert "Divide by zero error" in str(excinfo.value)
+    # Check that we've still got the output up until the error occured
+    with open(tmp_path / "output.csv", "r") as f:
+        contents = f.read().strip()
+    assert contents == "value\n-250\n-333\n-500\n-1000"

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1,5 +1,4 @@
 import csv
-import filecmp
 import os
 import subprocess
 import tempfile
@@ -1494,7 +1493,11 @@ def test_sqlcmd_and_odbc_outputs_match():
         study.to_csv(input_csv_odbc.name, with_sqlcmd=False)
         # unix line endings
         study.to_csv(input_csv_sqlcmd.name, with_sqlcmd=True)
-        assert filecmp.cmp(input_csv_odbc.name, input_csv_sqlcmd.name, shallow=False)
+        with open(input_csv_odbc.name) as f:
+            odbc_output = f.read()
+        with open(input_csv_sqlcmd.name) as f:
+            sqlcmd_output = f.read()
+        assert odbc_output == sqlcmd_output
 
 
 def test_column_name_clashes_produce_errors():


### PR DESCRIPTION
Previously this code used the `-o output_file` option. This caused both
query output and warnings/errors to be mixed together in a single file,
which then required hairy and error prone code to try to separate back
out.

We now just let sqlcmd write to stdout, which we redirect to a file
ourselves, leaving error output written to stderr.

Closes #239