### PR TITLE
Support writing results to intermediate table

### DIFF
--- a/.env-test
+++ b/.env-test
@@ -1,3 +1,4 @@
 TPP_DATABASE_URL=mssql://SA:Your_password123!@localhost:15785/Test_OpenCorona
+TPP_TEMP_DATABASE_NAME=OPENCoronaTempTables
 ACME_DATABASE_URL=presto://localhost:8080/mssql/dbo
 ACME_DATASOURCE_DATABASE_URL=mssql://SA:Your_password123!@localhost:15785/Test_ACME

--- a/cohortextractor/acme_backend.py
+++ b/cohortextractor/acme_backend.py
@@ -19,7 +19,7 @@ class ACMEBackend:
     _db_connection = None
     _current_column_name = None
 
-    def __init__(self, database_url, covariate_definitions):
+    def __init__(self, database_url, covariate_definitions, temporary_database=None):
         self.database_url = database_url
         self.covariate_definitions = covariate_definitions
         self.codelist_tables = []

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -16,9 +16,14 @@ class StudyDefinition:
         self.covariate_definitions = process_covariate_definitions(covariates)
         self.pandas_csv_args = self.get_pandas_csv_args(self.covariate_definitions)
         database_url = os.environ.get("DATABASE_URL")
+        temporary_database = os.environ.get("TEMP_DATABASE_NAME")
         if database_url:
             Backend = self.get_backend_for_database_url(database_url)
-            self.backend = Backend(database_url, self.covariate_definitions)
+            self.backend = Backend(
+                database_url,
+                self.covariate_definitions,
+                temporary_database=temporary_database,
+            )
         else:
             # Without a backend defined we can still generate dummy data but we
             # can't rely on the backend to validate the study definition for us

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1,7 +1,10 @@
 import csv
 import datetime
 import enum
+import hashlib
 import re
+
+import pyodbc
 
 from .expressions import format_expression
 from .mssql_utils import (
@@ -20,17 +23,28 @@ class TPPBackend:
     _db_connection = None
     _current_column_name = None
 
-    def __init__(self, database_url, covariate_definitions):
+    def __init__(self, database_url, covariate_definitions, temporary_database=None):
         self.database_url = database_url
         self.covariate_definitions = covariate_definitions
+        self.temporary_database = temporary_database
         self.codelist_tables = []
         self.queries = self.get_queries(self.covariate_definitions)
 
     def to_csv(self, filename, with_sqlcmd=False):
         unique_check = UniqueCheck()
         queries = self.to_sql_list()
+        # If we have a temporary database available we write results to a table
+        # there, download them, and then delete the table. This allows us to
+        # resume in the case of a failed download without rerunning the whole
+        # query
+        if self.temporary_database:
+            queries, cleanup_queries = self.save_results_to_temporary_db(queries)
+        else:
+            cleanup_queries = []
         for patient_id in self._to_csv(filename, queries, with_sqlcmd=with_sqlcmd):
             unique_check.add(patient_id)
+        if cleanup_queries:
+            self.execute_queries(cleanup_queries)
         unique_check.assert_unique_ids()
 
     def _to_csv(self, filename, queries, with_sqlcmd=False):
@@ -83,6 +97,52 @@ class TPPBackend:
         for name, query in self.queries:
             queries.append(f"-- Query for {name}\n{query}")
         return queries
+
+    def save_results_to_temporary_db(self, queries):
+        """
+        Sometimes there are glitches (network issues?) which occur when
+        downloading large result sets. To avoid having to recompute these each
+        time we can write the results to a table which we only delete once
+        we've fully downloaded its contents. If the download is interrupted
+        then subsequent runs will pick up the table and download it without
+        having to re-run all the queries.
+        """
+        assert self.temporary_database
+        # We're using the hash of all the queries as a cache key. Obviously
+        # this doesn't take into account the fact that the data itself may
+        # change, but for our purposes this doesn't matter: this is designed to
+        # be a very short-lived cache which is deleted as soon as the data is
+        # successfully downloaded
+        query_hash = hashlib.sha1("\n".join(queries).encode("utf8")).hexdigest()
+        output_table = f"{self.temporary_database}..DataExtract_{query_hash}"
+        if not self.table_exists(output_table):
+            queries = list(queries)
+            final_query = queries.pop()
+            self.execute_queries(queries)
+            # We need to run the final query in a transaction so that we don't end up
+            # with an empty output table in the event that the query fails. See:
+            # https://docs.microsoft.com/en-us/sql/t-sql/queries/select-into-clause-transact-sql?view=sql-server-ver15#remarks
+            conn = self.get_db_connection()
+            conn.autocommit = False
+            conn.execute(f"SELECT * INTO {output_table} FROM ({final_query}) t")
+            conn.commit()
+            conn.autocommit = True
+        return [f"SELECT * FROM {output_table}"], [f"DROP TABLE {output_table}"]
+
+    def table_exists(self, table_name):
+        # We don't have access to sys.tables so this seems like the simplest
+        # way of testing for table existence
+        cursor = self.get_db_connection().cursor()
+        try:
+            cursor.execute(f"SELECT 1 FROM {table_name}")
+            list(cursor)
+            return True
+        except pyodbc.ProgrammingError as e:
+            # This is the error code for "Invalid object name"
+            if e.args[0] == "42S02":
+                return False
+            else:
+                raise
 
     def get_queries(self, covariate_definitions):
         output_columns = {}

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -4,8 +4,6 @@ import enum
 import hashlib
 import re
 
-import pyodbc
-
 from .expressions import format_expression
 from .mssql_utils import (
     mssql_pyodbc_connection_from_url,
@@ -137,7 +135,12 @@ class TPPBackend:
             cursor.execute(f"SELECT 1 FROM {table_name}")
             list(cursor)
             return True
-        except pyodbc.ProgrammingError as e:
+        # Really we ought to be catching `pyodbc.ProgrammingError` here, but
+        # for $REASONS we want to avoid depending on pyodbc directly in this
+        # module. Because we're checking a specific error code and re-raising
+        # otherwise, this overbroad exception handling shouldn't be a problem
+        # in practice.
+        except Exception as e:
             # This is the error code for "Invalid object name"
             if e.args[0] == "42S02":
                 return False

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2330,7 +2330,7 @@ def test_patients_attended_accident_and_emergency():
     )
 
     assert_results(
-        study,
+        study.to_dicts(),
         attended=["0", "0", "1", "1"],
         count=["0", "0", "1", "3"],
         first_date=["", "", "2020-03-01", "2020-03-01"],
@@ -2403,11 +2403,10 @@ def test_patients_date_deregistered_from_all_supported_practices():
             on_or_before="2018-02-01", date_format="YYYY-MM",
         ),
     )
-    assert_results(study, dereg_date=["", "", "2017-10"])
+    assert_results(study.to_dicts(), dereg_date=["", "", "2017-10"])
 
 
-def assert_results(study, **expected_values):
-    results = study.to_dicts()
+def assert_results(results, **expected_values):
     for col_name, expected_col_values in expected_values.items():
         col_values = [row[col_name] for row in results]
         assert col_values == expected_col_values, f"Unexpected results for {col_name}"


### PR DESCRIPTION
Sometimes the queries to extract study data will run successfully but
something will interrupt the download process and then the entire query
will need to be run again.

This PR adds support for writing results to a table in a temporary
database before downloading. If the download is interrupted then a
re-run of the extraction process will pick up the previously created
table and download it without having to re-run the queries.

Once the data is successfully downloaded the table is deleted.

In order to use this feature the environment variable
`TEMP_DATABASE_NAME` must be set. This will require a change to the job
runner and updated instructions for those running extracts manually.

Fixes #241