### PR TITLE
Add basic validation of SQL expressions

### DIFF
--- a/cohortextractor/expressions.py
+++ b/cohortextractor/expressions.py
@@ -40,7 +40,8 @@ def format_expression(expression, name_map, empty_value_map):
     tokens = tree[0].flatten()
     tokens = filter_and_validate_tokens(tokens)
     tokens = insert_implicit_comparisons(tokens, empty_value_map)
-    tokens = validate_expression(tokens, empty_value_map)
+    tokens = list(tokens)
+    validate_expression(tokens, empty_value_map)
     tokens = remap_names(tokens, name_map)
     return " ".join(token.value for token in tokens)
 
@@ -172,7 +173,6 @@ def validate_expression(tokens, empty_value_map):
     operations on non-numeric types. But it at least catches basic syntactic
     errors.
     """
-    tokens = list(tokens)
     sql = " ".join(
         replace_names_with_empty_values(token, empty_value_map) for token in tokens
     )
@@ -181,7 +181,6 @@ def validate_expression(tokens, empty_value_map):
         conn.execute(f"SELECT ({sql})")
     except sqlite3.OperationalError as e:
         raise ValueError(f"Invalid SQL expression: {e}")
-    return tokens
 
 
 def replace_names_with_empty_values(token, empty_value_map):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,22 @@
+import pytest
+
+from cohortextractor.expressions import format_expression
+
+
+def test_basic_expression_rewritting():
+    output = format_expression(
+        "foo AND (bar > 3 OR baz = 'hello')",
+        name_map={"foo": "table1.foo", "bar": "table2.bar", "baz": "other"},
+        empty_value_map={"foo": 0, "bar": 0, "baz": ""},
+    )
+    assert output == "( table1.foo != 0 ) AND ( table2.bar > 3 OR other = 'hello' )"
+
+
+def test_validation():
+    kwargs = dict(name_map={"a": "a", "b": "b"}, empty_value_map={"a": 0, "b": 0})
+    with pytest.raises(ValueError):
+        format_expression("a AND AND b", **kwargs)
+    with pytest.raises(ValueError):
+        format_expression("(a AND b", **kwargs)
+    with pytest.raises(ValueError):
+        format_expression("a > > b", **kwargs)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cohortextractor.expressions import format_expression
+from cohortextractor.expressions import format_expression, InvalidExpressionError
 
 
 def test_basic_expression_rewritting():
@@ -14,9 +14,9 @@ def test_basic_expression_rewritting():
 
 def test_validation():
     kwargs = dict(name_map={"a": "a", "b": "b"}, empty_value_map={"a": 0, "b": 0})
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidExpressionError):
         format_expression("a AND AND b", **kwargs)
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidExpressionError):
         format_expression("(a AND b", **kwargs)
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidExpressionError):
         format_expression("a > > b", **kwargs)

--- a/tests/test_study_definition.py
+++ b/tests/test_study_definition.py
@@ -97,3 +97,25 @@ def test_pyodbc_not_accidentally_imported(tmp_path):
     source = textwrap.dedent("\n".join(source))
     result = subprocess.check_output([sys.executable, "-c", source]).strip()
     assert result == b"pyodbc is not imported"
+
+
+def test_column_name_clashes_produce_errors():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            age=patients.age_as_of("2020-01-01"),
+            status=patients.satisfying(
+                "age > 70 AND sex = 'M'",
+                sex=patients.sex(),
+                age=patients.age_as_of("2010-01-01"),
+            ),
+        )
+
+
+def test_recursive_definitions_produce_errors():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            this=patients.satisfying("that = 1"),
+            that=patients.satisfying("this = 1"),
+        )

--- a/tests/test_study_definition.py
+++ b/tests/test_study_definition.py
@@ -119,3 +119,15 @@ def test_recursive_definitions_produce_errors():
             this=patients.satisfying("that = 1"),
             that=patients.satisfying("this = 1"),
         )
+
+
+def test_syntax_errors_in_expressions_are_raised():
+    with pytest.raises(ValueError):
+        StudyDefinition(
+            population=patients.all(),
+            status=patients.satisfying(
+                "age > 70 AND AND sex = 'M'",
+                sex=patients.sex(),
+                age=patients.age_as_of("2010-01-01"),
+            ),
+        )

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1511,28 +1511,6 @@ def test_sqlcmd_and_odbc_outputs_match(tmp_path):
     assert odbc_output == sqlcmd_output
 
 
-def test_column_name_clashes_produce_errors():
-    with pytest.raises(ValueError):
-        StudyDefinition(
-            population=patients.all(),
-            age=patients.age_as_of("2020-01-01"),
-            status=patients.satisfying(
-                "age > 70 AND sex = 'M'",
-                sex=patients.sex(),
-                age=patients.age_as_of("2010-01-01"),
-            ),
-        )
-
-
-def test_recursive_definitions_produce_errors():
-    with pytest.raises(ValueError):
-        StudyDefinition(
-            population=patients.all(),
-            this=patients.satisfying("that = 1"),
-            that=patients.satisfying("this = 1"),
-        )
-
-
 def test_using_expression_in_population_definition():
     session = make_session()
     session.add_all(


### PR DESCRIPTION
This piggybacks off SQLite to avoid having to do our own validation.
Unfortunately this means it doesn't do any type-checking as SQLite
doesn't really do types. But still, it's better than nothing.

Partially addresses #192