### PR TITLE
fix: tag docker image with version

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -72,4 +72,4 @@ jobs:
         password: "${{ secrets.GITHUB_TOKEN }}"
         registry: docker.pkg.github.com
         image_name: cohort-extractor
-        push_git_tag: true
+        image_tag: latest,${{ needs.tag-new-version.outputs.tag }}


### PR DESCRIPTION
According to the documentation, `push_git_tag` was meant to do this by
applying the current tag from the tip, but for some reason it wasn't.

Doing it explicitly is more comprehensible, in any case.