### PR TITLE
Add "index_date" support

### DIFF
--- a/cohortextractor/date_expressions.py
+++ b/cohortextractor/date_expressions.py
@@ -1,0 +1,110 @@
+import calendar
+import datetime
+import re
+
+
+class InvalidExpressionError(ValueError):
+    pass
+
+
+class UnparseableExpressionError(InvalidExpressionError):
+    pass
+
+
+def create_regex():
+    token = r"[A-Za-z_\-\.]+"
+    name = f"(?P<name>{token})"
+    function = f"(?P<function>{token})"
+    operator = r"(?P<operator> \+ | \-)"
+    quantity = r"(?P<quantity>\d+)"
+    units = f"(?P<units>{token})"
+    return re.compile(
+        rf"^( {function} \( )? {name} \)? ( {operator} {quantity} {units} )?$",
+        re.VERBOSE,
+    )
+
+
+class DateExpressionEvaluator:
+
+    regex = create_regex()
+
+    def __init__(self, index_date):
+        self.index_date = index_date
+
+    def __call__(self, expression_str):
+        match = self.regex.match(expression_str.replace(" ", ""))
+        if not match:
+            raise UnparseableExpressionError(expression_str)
+        try:
+            return self.evaluate(**match.groupdict())
+        except InvalidExpressionError as e:
+            message = f"{e} in: {expression_str}"
+            e.args = (message, *e.args[1:])
+            raise e
+
+    def evaluate(self, name, function, operator, quantity, units):
+        date = self.get_method("name", name)()
+        if function:
+            date_function = self.get_method("function", function)
+            date = date_function(date)
+        if operator:
+            value = int(quantity)
+            if operator == "-":
+                value = -value
+            add_units = self.get_method("unit", units)
+            date = add_units(date, value)
+        return date.isoformat()
+
+    def get_method(self, method_type, name):
+        prefix = f"date_{method_type}_"
+        try:
+            return getattr(self, f"{prefix}{name}")
+        except AttributeError:
+            methods = [n[len(prefix) :] for n in dir(self) if n.startswith(prefix)]
+            raise InvalidExpressionError(
+                f"Unknown date {method_type} '{name}' "
+                f"(allowed are {', '.join(methods)})"
+            )
+
+    def date_name_today(self):
+        # There's a question mark over whether we should support this at all,
+        # see: https://github.com/opensafely/cohort-extractor/issues/237
+        return datetime.date.today()
+
+    def date_name_index_date(self):
+        if not self.index_date:
+            raise InvalidExpressionError("index_date not defined")
+        return datetime.date.fromisoformat(self.index_date)
+
+    def date_function_first_day_of_month(self, date):
+        return date.replace(day=1)
+
+    def date_function_last_day_of_month(self, date):
+        days_in_month = calendar.monthrange(date.year, date.month)[1]
+        return date.replace(day=days_in_month)
+
+    def date_function_first_day_of_year(self, date):
+        return date.replace(month=1, day=1)
+
+    def date_function_last_day_of_year(self, date):
+        return date.replace(month=12, day=31)
+
+    def date_unit_years(self, date, value):
+        # This can potentially throw an error if used on 29 Feb
+        return date.replace(year=date.year + value)
+
+    def date_unit_months(self, date, value):
+        # Can potentially thrown an error if day is greater than 28 and there's
+        # no corresponding day in the resulting month
+        zero_based_month = (date.month - 1) + value
+        new_month = (zero_based_month % 12) + 1
+        new_year = date.year + (zero_based_month // 12)
+        return date.replace(year=new_year, month=new_month)
+
+    def date_unit_days(self, date, value):
+        return date + datetime.timedelta(days=value)
+
+    # Define the singular units as aliases to the plural
+    date_unit_year = date_unit_years
+    date_unit_month = date_unit_months
+    date_unit_day = date_unit_days

--- a/cohortextractor/date_expressions.py
+++ b/cohortextractor/date_expressions.py
@@ -42,6 +42,7 @@ class DateExpressionEvaluator:
         try:
             return self.evaluate(**match.groupdict())
         except (InvalidExpressionError, InvalidDateError) as e:
+            # Add the expression to the error message for easier debugging
             message = f"{e} in: {expression_str}"
             e.args = (message, *e.args[1:])
             raise e

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -1,6 +1,8 @@
 import copy
 import datetime
 
+from .date_expressions import DateExpressionEvaluator, UnparseableExpressionError
+
 
 def process_covariate_definitions(covariate_definitions, index_date=None):
     """
@@ -416,14 +418,12 @@ def process_expectations_definition(expectations_definition, index_date):
 def process_date_expression(date_str, index_date):
     if date_str is None:
         return None
-    # There's a question mark over whether we should support this at all, see:
-    # https://github.com/opensafely/cohort-extractor/issues/237
-    if date_str == "today":
-        return datetime.date.today().isoformat()
-    elif date_str == "index_date":
-        return index_date
-    else:
-        validate_date(date_str)
+    parse_expression = DateExpressionEvaluator(index_date)
+    try:
+        return parse_expression(date_str)
+    except UnparseableExpressionError:
+        pass
+    validate_date(date_str)
     return date_str
 
 

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -388,16 +388,25 @@ def process_date_expressions(covariate_definitions):
                 process_date_expression(start),
                 process_date_expression(end),
             )
-        for key in ("earliest", "latest"):
-            try:
-                value = query_args["return_expectations"]["date"][key]
-            except (KeyError, TypeError):
-                continue
-            query_args["return_expectations"]["date"][key] = process_date_expression(
-                value
+        if "return_expectations" in query_args:
+            query_args["return_expectations"] = process_expectations_definition(
+                query_args["return_expectations"]
             )
         output[name] = (query_type, query_args)
     return output
+
+
+def process_expectations_definition(expectations_definition):
+    if not expectations_definition:
+        return expectations_definition
+    expectations_definition = copy.deepcopy(expectations_definition)
+    for key in ("earliest", "latest"):
+        try:
+            value = expectations_definition["date"][key]
+        except (KeyError, TypeError):
+            continue
+        expectations_definition["date"][key] = process_date_expression(value)
+    return expectations_definition
 
 
 def process_date_expression(date_str):

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -381,6 +381,11 @@ class GetColumnType:
 
 
 def process_date_expressions(covariate_definitions, index_date):
+    """
+    Take a covariate definition and parse every date reference within it (which
+    might be expressions such as "index_date + 1 month") replacing them all
+    with ISO date strings and returning the modified definition
+    """
     output = {}
     for name, (query_type, query_args) in covariate_definitions.items():
         for key in ("reference_date", "start_date", "end_date"):
@@ -393,14 +398,22 @@ def process_date_expressions(covariate_definitions, index_date):
                 process_date_expression(end, index_date),
             )
         if "return_expectations" in query_args:
-            query_args["return_expectations"] = process_expectations_definition(
+            return_expectations = process_date_expressions_in_expectations_definition(
                 query_args["return_expectations"], index_date
             )
+            query_args["return_expectations"] = return_expectations
         output[name] = (query_type, query_args)
     return output
 
 
-def process_expectations_definition(expectations_definition, index_date):
+def process_date_expressions_in_expectations_definition(
+    expectations_definition, index_date
+):
+    """
+    Take an expectations definition and parse every date reference within it
+    (which might be expressions such as "index_date + 1 month") replacing them
+    all with ISO date strings and returning the modified definition
+    """
     if not expectations_definition:
         return expectations_definition
     expectations_definition = copy.deepcopy(expectations_definition)
@@ -416,12 +429,21 @@ def process_expectations_definition(expectations_definition, index_date):
 
 
 def process_date_expression(date_str, index_date):
+    """
+    Return an ISO date string from a date expression (e.g "index_date + 1
+    month") and index date
+
+    `date_str` can also just be an ISO date string to start with, in which case
+    it is validated but not further modified.
+    """
     if date_str is None:
         return None
     parse_expression = DateExpressionEvaluator(index_date)
     try:
         return parse_expression(date_str)
     except UnparseableExpressionError:
+        # If we can't parse it as an expression that we just attempt to
+        # validate it as an ISO date
         pass
     validate_date(date_str)
     return date_str

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -5,13 +5,18 @@ import os
 import pandas as pd
 
 from .expectation_generators import generate
-from .process_covariate_definitions import process_covariate_definitions
+from .process_covariate_definitions import (
+    process_covariate_definitions,
+    process_expectations_definition,
+)
 
 
 class StudyDefinition:
-    def __init__(self, population, **covariates):
+    def __init__(self, population, default_expectations=None, **covariates):
         covariates["population"] = population
-        self.default_expectations = covariates.pop("default_expectations", {})
+        self.default_expectations = process_expectations_definition(
+            default_expectations or {}
+        )
         self.covariate_definitions = process_covariate_definitions(covariates)
         self.pandas_csv_args = self.get_pandas_csv_args(self.covariate_definitions)
         database_url = os.environ.get("DATABASE_URL")

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -1,6 +1,5 @@
 import collections
 import copy
-import datetime
 import os
 
 import pandas as pd
@@ -202,7 +201,7 @@ class StudyDefinition:
                 )
             kwargs = self.default_expectations.copy()
             kwargs = merge(kwargs, return_expectations)
-            self.convert_today_string_to_date(colname, kwargs)
+            self.check_date_expectations_defined(colname, kwargs)
             df[colname] = generate(population, **kwargs)["date"]
 
             # Now apply any date-based filtering specified in the study
@@ -221,7 +220,7 @@ class StudyDefinition:
             kwargs = merge(
                 kwargs, self.pandas_csv_args["args"][colname]["return_expectations"]
             )
-            self.convert_today_string_to_date(colname, kwargs)
+            self.check_date_expectations_defined(colname, kwargs)
 
             if dtype == "category":
                 self.validate_category_expectations(
@@ -296,12 +295,12 @@ class StudyDefinition:
             series = series.dt.strftime("%Y")
         return series
 
-    def convert_today_string_to_date(self, colname, kwargs):
+    def check_date_expectations_defined(self, colname, kwargs):
         if "date" not in kwargs:
             raise ValueError(f"{colname} must define a date expectation")
         for k in ["earliest", "latest"]:
-            if kwargs["date"][k] == "today":
-                kwargs["date"][k] = datetime.datetime.now().strftime("%Y-%m-%d")
+            if k not in kwargs["date"]:
+                raise ValueError(f"{colname} must define a date[{k}] expectation")
 
 
 def merge(dict1, dict2):

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -12,12 +12,16 @@ from .process_covariate_definitions import (
 
 
 class StudyDefinition:
-    def __init__(self, population, default_expectations=None, **covariates):
+    def __init__(
+        self, population, default_expectations=None, index_date=None, **covariates
+    ):
         covariates["population"] = population
         self.default_expectations = process_expectations_definition(
-            default_expectations or {}
+            default_expectations or {}, index_date
         )
-        self.covariate_definitions = process_covariate_definitions(covariates)
+        self.covariate_definitions = process_covariate_definitions(
+            covariates, index_date
+        )
         self.pandas_csv_args = self.get_pandas_csv_args(self.covariate_definitions)
         database_url = os.environ.get("DATABASE_URL")
         temporary_database = os.environ.get("TEMP_DATABASE_NAME")

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -7,7 +7,7 @@ import pandas as pd
 from .expectation_generators import generate
 from .process_covariate_definitions import (
     process_covariate_definitions,
-    process_expectations_definition,
+    process_date_expressions_in_expectations_definition,
 )
 
 
@@ -16,7 +16,7 @@ class StudyDefinition:
         self, population, default_expectations=None, index_date=None, **covariates
     ):
         covariates["population"] = population
-        self.default_expectations = process_expectations_definition(
+        self.default_expectations = process_date_expressions_in_expectations_definition(
             default_expectations or {}, index_date
         )
         self.covariate_definitions = process_covariate_definitions(

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1343,7 +1343,7 @@ class TPPBackend:
         return columns, sql
 
     def patients_household_as_of(self, reference_date, returning):
-        if reference_date.isoformat() != "2020-02-01":
+        if reference_date != "2020-02-01":
             raise ValueError("Household data only currently available for 2020-02-01")
         if returning == "pseudo_id":
             column = "Household.Household_ID"

--- a/tests/test_date_expressions.py
+++ b/tests/test_date_expressions.py
@@ -1,6 +1,8 @@
 import datetime
 
-from cohortextractor.date_expressions import DateExpressionEvaluator
+import pytest
+
+from cohortextractor.date_expressions import DateExpressionEvaluator, InvalidDateError
 
 
 def test_date_expression_evaluator():
@@ -16,3 +18,10 @@ def test_date_expression_evaluator():
     assert expr("first_day_of_year(index_date)") == "2017-01-01"
     assert expr("last_day_of_year(index_date)") == "2017-12-31"
     assert expr("first_day_of_month(index_date) - 15 days") == "2017-07-17"
+
+
+def test_date_expression_evaluator_errors():
+    with pytest.raises(InvalidDateError, match="No such date 29 February 2021"):
+        DateExpressionEvaluator("2020-02-29")("index_date + 1 year")
+    with pytest.raises(InvalidDateError, match="No such date 31 February 2020"):
+        DateExpressionEvaluator("2020-01-31")("index_date + 1 month")

--- a/tests/test_date_expressions.py
+++ b/tests/test_date_expressions.py
@@ -1,0 +1,18 @@
+import datetime
+
+from cohortextractor.date_expressions import DateExpressionEvaluator
+
+
+def test_date_expression_evaluator():
+    expr = DateExpressionEvaluator(index_date="2017-08-19")
+    assert expr("today") == datetime.date.today().isoformat()
+    assert expr("index_date") == "2017-08-19"
+    assert expr("index_date + 1 day") == "2017-08-20"
+    assert expr("index_date - 30 days") == "2017-07-20"
+    assert expr("index_date + 5 months") == "2018-01-19"
+    assert expr("index_date + 2 years") == "2019-08-19"
+    assert expr("first_day_of_month(index_date)") == "2017-08-01"
+    assert expr("last_day_of_month(index_date)") == "2017-08-31"
+    assert expr("first_day_of_year(index_date)") == "2017-01-01"
+    assert expr("last_day_of_year(index_date)") == "2017-12-31"
+    assert expr("first_day_of_month(index_date) - 15 days") == "2017-07-17"

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2463,3 +2463,16 @@ def test_large_codelists_upload_correctly():
     )
     results = study.to_dicts()
     assert_results(results, value=["7.0", "11.0", "18.0"])
+
+
+def test_use_of_index_date():
+    session = make_session()
+    session.add_all([Patient(DateOfBirth="1980-01-01",)])
+    session.commit()
+    study = StudyDefinition(
+        index_date="2015-01-01",
+        population=patients.all(),
+        age=patients.age_as_of("index_date"),
+    )
+    results = study.to_dicts()
+    assert_results(results, age=["35"])


### PR DESCRIPTION
This PR adds "index_date" support to study definitions. Here is a simple example of what this looks like:

```py
study = StudyDefinition(
    index_date="2015-06-01",
    population=patients.with_these_clinical_events(
        copd_codes,
        between=[
            "first_day_of_year(index_date) - 2 years",
            "last_day_of_year(index_date)",
        ],
    ),
    age=patients.age_as_of("index_date"),
)
```

If you define an `index_date` on a study definition then everywhere that you might normally supply a date you can now supply a "date expression".

The simplest date expression is just the string `index_date`, which gets replaced by whatever the index date is set to.

It's also possible to apply various functions to the index date. The available options (hopefully self-explanatory) are:
```
first_day_of_month(index_date)
last_day_of_month(index_date)
first_day_of_year(index_date)
last_day_of_year(index_date) 
```

Finally, intervals of time can be added or subtracted from the index date (or from a function applied to the index date). The available units are `year(s)`, `month(s)` and `day(s)`. For example:
```
index_date + 90 days
first_day_of_month(index_date) + 9 months
index_date - 1 year
```

Note that if the index date is 29 February and you add or subtract some number of years which doesn't lead to a leap year, then an error will be thrown. Similarly, if adding or subtracting months leads to a month with no equivalent day e.g. adding 1 month to 31 January to produce 31 February. 


