### PR TITLE
fix: Remove default True value from deprecated argument

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -271,7 +271,7 @@ def admitted_to_icu(
     # Required keyword
     return_expectations=None,
     # Deprecated options kept for now for backwards compatibility
-    include_month=True,
+    include_month=False,
     include_day=False,
 ):
     """Return information about being admitted to ICU.


### PR DESCRIPTION
This triggered an error when attempting to use the non-deprecated
`date_format` argument. And the default shouldn't have been True in
any case.

Closes #261