### PR TITLE
feat: Support querying date-of-death from GP record

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -356,6 +356,32 @@ def with_death_recorded_in_cpns(
     return "with_death_recorded_in_cpns", locals()
 
 
+def with_death_recorded_in_primary_care(
+    # Set date limits
+    on_or_before=None,
+    on_or_after=None,
+    between=None,
+    # Set return type
+    returning="binary_flag",
+    date_format=None,
+    return_expectations=None,
+):
+    """
+    Identify patients with a date-of-death in their primary care record.
+
+    There is generally a lag between the death being recorded in ONS data and
+    appearing in the primary care record, but the date itself is usually
+    reliable when it appears. By contrast, cause of death is often not accurate
+    in the primary care record so we don't make it available to query here.
+
+    Options for `returning` are:
+
+       binary_flag: If they died or not
+       date_of_death: Date of death
+    """
+    return "with_death_recorded_in_primary_care", locals()
+
+
 def date_of(
     source,
     date_format=None,

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -290,6 +290,9 @@ class GetColumnType:
     def type_of_with_death_recorded_in_cpns(self, returning, **kwargs):
         return self._type_from_return_value(returning)
 
+    def type_of_with_death_recorded_in_primary_care(self, returning, **kwargs):
+        return self._type_from_return_value(returning)
+
     def type_of_with_tpp_vaccination_record(self, returning, **kwargs):
         return self._type_from_return_value(returning)
 

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1144,6 +1144,43 @@ class TPPBackend:
             """,
         )
 
+    def patients_with_death_recorded_in_primary_care(
+        self,
+        # Set date limits
+        between=None,
+        # Set return type
+        returning="binary_flag",
+    ):
+        if returning == "binary_flag":
+            column = "1"
+        elif returning == "date_of_death":
+            column = "DateOfDeath"
+        else:
+            raise ValueError(f"Unsupported `returning` value: {returning}")
+        if between is None:
+            between = (None, None)
+        min_date, max_date = between
+        # Patients with no date of death (i.e. alive ones) are recorded using a
+        # death date of 9999-12-31, so if no max date is supplied then we need
+        # to set a max date to something less than 9999-12-31 to filter these
+        # out
+        if max_date is None:
+            max_date = "3000-01-01"
+        if min_date is None:
+            min_date = "1900-01-01"
+        return (
+            ["patient_id", returning],
+            f"""
+            SELECT
+              Patient_ID AS patient_id,
+              {column} AS {returning}
+            FROM
+              Patient
+            WHERE
+              DateOfDeath BETWEEN {quote(min_date)} AND {quote(max_date)}
+            """,
+        )
+
     def patients_with_tpp_vaccination_record(
         self,
         target_disease_matches=None,


### PR DESCRIPTION
Usage is pretty much what you'd expect:
```py

study = StudyDefinition(
    population=patients.all(),
    date_of_death=patients.with_death_recorded_in_primary_care(
        returning="date_of_death",
        date_format="YYYY-MM-DD",
    ),
    died_in_2019=patients.with_death_recorded_in_primary_care(
        between=["2019-01-01", "2019-12-31"],
        returning="binary_flag",
    ),
)
```

Closes #263