### PR TITLE
Allow passing temporary db name on command line

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -365,6 +365,12 @@ def main():
         choices=["all"] + [x[0] for x in list_study_definitions()],
         default="all",
     )
+    generate_cohort_parser.add_argument(
+        "--temp-database-name",
+        help="Name of database so store temporary results",
+        type=str,
+        default=os.environ.get("TEMP_DATABASE_NAME", ""),
+    )
     cohort_method_group = generate_cohort_parser.add_mutually_exclusive_group(
         required=True
     )
@@ -388,6 +394,8 @@ def main():
         parser.print_help()
     elif options.which == "generate_cohort":
         os.environ["DATABASE_URL"] = options.database_url
+        if options.temp_database_name:
+            os.environ["TEMP_DATABASE_NAME"] = options.temp_database_name
         generate_cohort(
             options.output_dir,
             options.expectations_population,

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -122,9 +122,12 @@ class TPPBackend:
             # https://docs.microsoft.com/en-us/sql/t-sql/queries/select-into-clause-transact-sql?view=sql-server-ver15#remarks
             conn = self.get_db_connection()
             conn.autocommit = False
+            self.log(f"Writing results into temporary table '{output_table}'")
             conn.execute(f"SELECT * INTO {output_table} FROM ({final_query}) t")
             conn.commit()
             conn.autocommit = True
+        else:
+            self.log(f"Downloading results from previous run in '{output_table}'")
         return [f"SELECT * FROM {output_table}"], [f"DROP TABLE {output_table}"]
 
     def table_exists(self, table_name):

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2230,7 +2230,11 @@ def test_patients_attended_accident_and_emergency():
                         Arrival_Date="2020-05-01",
                         Discharge_Destination_SNOMED_CT=discharge_to_ward,
                         Diagnoses=[
-                            EC_Diagnosis(Patient_ID=3, EC_Diagnosis_01=covid_19, EC_Diagnosis_02=not_covid_19)
+                            EC_Diagnosis(
+                                Patient_ID=3,
+                                EC_Diagnosis_01=covid_19,
+                                EC_Diagnosis_02=not_covid_19,
+                            )
                         ],
                     ),
                     EC(
@@ -2238,7 +2242,11 @@ def test_patients_attended_accident_and_emergency():
                         Arrival_Date="2020-07-01",
                         Discharge_Destination_SNOMED_CT=discharge_to_ward,
                         Diagnoses=[
-                            EC_Diagnosis(Patient_ID=3, EC_Diagnosis_01=not_covid_19, EC_Diagnosis_02=covid_19)
+                            EC_Diagnosis(
+                                Patient_ID=3,
+                                EC_Diagnosis_01=not_covid_19,
+                                EC_Diagnosis_02=covid_19,
+                            )
                         ],
                     ),
                 ],

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -169,9 +169,7 @@ class Patient(Base):
         "EC", back_populates="Patient", cascade="all, delete, delete-orphan",
     )
     ECDiagnoses = relationship(
-        "EC_Diagnosis",
-        back_populates="Patient",
-        cascade="all, delete, delete-orphan",
+        "EC_Diagnosis", back_populates="Patient", cascade="all, delete, delete-orphan",
     )
     APCSEpisodes = relationship(
         "APCS", back_populates="Patient", cascade="all, delete, delete-orphan",
@@ -480,6 +478,7 @@ class EC_Diagnosis(Base):
     EC_Diagnosis_22 = Column(String(collation="Latin1_General_CI_AS"))
     EC_Diagnosis_23 = Column(String(collation="Latin1_General_CI_AS"))
     EC_Diagnosis_24 = Column(String(collation="Latin1_General_CI_AS"))
+
 
 class APCS(Base):
     __tablename__ = "APCS"


### PR DESCRIPTION
Example:
```
cohortextractor generate_cohort --database-url XXXXX --temp-database-name OPENCoronaTempTables
```
This PR also checks that temporary database exists before running the queries and adds a bit more logging.