### PR TITLE
feat: rename docker image

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -71,5 +71,5 @@ jobs:
         username: docker
         password: "${{ secrets.OPENSAFELY_DOCKER_PASSWORD }}"
         registry: docker.opensafely.org
-        image_name: cohort-extractor
+        image_name: cohortextractor
         image_tag: latest,${{ needs.tag-new-version.outputs.tag }}


### PR DESCRIPTION
This makes it consistent with the naming of the pip-installed console
script, thereby making running commands via docker or native python
more equivalent