### PR TITLE
feat: Distinguish partial and complete CSV files

### DIFF
--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1,4 +1,5 @@
 import csv
+import glob
 from unittest.mock import patch
 import os
 import subprocess
@@ -1495,6 +1496,12 @@ def test_duplicate_id_checking(tmp_path):
         study.to_dicts()
     with pytest.raises(RuntimeError):
         study.to_csv(tmp_path / "test.csv")
+    # Check that we don't produce a normal output file but we do leave a
+    # partial file
+    assert not os.path.exists(tmp_path / "test.csv")
+    partial_files = glob.glob(f"{tmp_path}/test.partial.*.csv")
+    print(partial_files)
+    assert len(partial_files) == 1
 
 
 def test_sqlcmd_and_odbc_outputs_match(tmp_path):


### PR DESCRIPTION
When errors occur during `generate_cohort` we want to keep the output
files around for debugging purposes but we want it to be clear that they
are not complete.

This PR produces files named like `input.partial.20200901-154348.csv`
which are only renamed to `input.csv` once the download is complete and
checks are passed.

Closes #278