### PR TITLE
Include non-ventilated patients in ICU results

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -279,8 +279,12 @@ def admitted_to_icu(
     Options for `returning` are:
 
         binary_flag: Whether patient attended A&E
-        was_ventilated: Whether patient was ventilated
         date_admitted: Date patient arrived in A&E
+        had_respiratory_support: Whether patient received any form of respiratory support
+        had_basic_respiratory_support": Whether patient received "basic" respiratory support
+        had_advanced_respiratory_support": Whether patient received "advanced" respiratory support
+
+        (Note that the terms "basic" and "advanced" are derived from the underlying ICNARC data.)
     """
 
     return "admitted_to_icu", locals()

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -340,7 +340,9 @@ class GetColumnType:
             "household_size": "int",
             "date_arrived": "date",
             "discharge_destination": "str",
-            "was_ventilated": "bool",
+            "had_respiratory_support": "bool",
+            "had_basic_respiratory_support": "bool",
+            "had_advanced_respiratory_support": "bool",
             "underlying_cause_of_death": "str",
             "primary_diagnosis": "str",
         }

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1081,7 +1081,15 @@ class TPPBackend:
             column_definition = 1
         elif returning == "was_ventilated":
             column_name = "ventilated"
-            column_definition = "MAX(Ventilator)"  # apparently can be 0, 1 or NULL
+            column_definition = """
+            CASE WHEN
+              SUM(BasicDays_RespiratorySupport) + SUM(AdvancedDays_RespiratorySupport) > 0
+            THEN
+              1
+            ELSE
+              0
+            END
+            """
         else:
             assert False, "`returning` must be one of `binary_flag` or `date_admitted`"
         return (
@@ -1093,8 +1101,7 @@ class TPPBackend:
             FROM
               ICNARC
             GROUP BY Patient_ID
-            HAVING
-              {date_condition} AND SUM(BasicDays_RespiratorySupport) + SUM(AdvancedDays_RespiratorySupport) >= 1
+            HAVING {date_condition}
             """,
         )
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1189,7 +1189,6 @@ def test_patients_admitted_to_icu():
             OriginalIcuAdmissionDate="2020-03-01",
             BasicDays_RespiratorySupport=2,
             AdvancedDays_RespiratorySupport=2,
-            Ventilator=0,
         )
     )
     patient_2 = Patient()
@@ -1199,19 +1198,9 @@ def test_patients_admitted_to_icu():
             OriginalIcuAdmissionDate="2020-02-01",
             BasicDays_RespiratorySupport=1,
             AdvancedDays_RespiratorySupport=0,
-            Ventilator=1,
         )
     )
     patient_3 = Patient()
-    patient_3.ICNARC.append(
-        ICNARC(
-            IcuAdmissionDateTime="2020-03-01",
-            OriginalIcuAdmissionDate="2020-02-01",
-            BasicDays_RespiratorySupport=0,
-            AdvancedDays_RespiratorySupport=0,
-            Ventilator=0,
-        )
-    )
     patient_4 = Patient()
     patient_4.ICNARC.append(
         ICNARC(
@@ -1219,7 +1208,6 @@ def test_patients_admitted_to_icu():
             OriginalIcuAdmissionDate="2020-01-01",
             BasicDays_RespiratorySupport=1,
             AdvancedDays_RespiratorySupport=0,
-            Ventilator=1,
         )
     )
     patient_5 = Patient()
@@ -1229,7 +1217,6 @@ def test_patients_admitted_to_icu():
             OriginalIcuAdmissionDate=None,
             BasicDays_RespiratorySupport=1,
             AdvancedDays_RespiratorySupport=0,
-            Ventilator=1,
         )
     )
     patient_5.ICNARC.append(
@@ -1238,7 +1225,6 @@ def test_patients_admitted_to_icu():
             OriginalIcuAdmissionDate=None,
             BasicDays_RespiratorySupport=0,
             AdvancedDays_RespiratorySupport=0,
-            Ventilator=1,
         )
     )
     session.add_all([patient_1, patient_2, patient_3, patient_4, patient_5])
@@ -1297,7 +1283,7 @@ def test_patients_admitted_to_icu():
         ),
     )
     results = study.to_dicts()
-    assert [i["icu"] for i in results] == ["0", "1", "0", "0", "1"]
+    assert [i["icu"] for i in results] == ["1", "1", "0", "0", "1"]
 
 
 def test_patients_with_these_codes_on_death_certificate():

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1500,7 +1500,6 @@ def test_duplicate_id_checking(tmp_path):
     # partial file
     assert not os.path.exists(tmp_path / "test.csv")
     partial_files = glob.glob(f"{tmp_path}/test.partial.*.csv")
-    print(partial_files)
     assert len(partial_files) == 1
 
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1215,8 +1215,8 @@ def test_patients_admitted_to_icu():
         ICNARC(
             IcuAdmissionDateTime="2020-03-01",
             OriginalIcuAdmissionDate=None,
-            BasicDays_RespiratorySupport=1,
-            AdvancedDays_RespiratorySupport=0,
+            BasicDays_RespiratorySupport=0,
+            AdvancedDays_RespiratorySupport=1,
         )
     )
     patient_5.ICNARC.append(
@@ -1279,11 +1279,29 @@ def test_patients_admitted_to_icu():
     study = StudyDefinition(
         population=patients.all(),
         icu=patients.admitted_to_icu(
-            on_or_after="2020-02-01", returning="was_ventilated",
+            on_or_after="2020-02-01", returning="had_respiratory_support",
         ),
     )
     results = study.to_dicts()
     assert [i["icu"] for i in results] == ["1", "1", "0", "0", "1"]
+
+    study = StudyDefinition(
+        population=patients.all(),
+        icu=patients.admitted_to_icu(
+            on_or_after="2020-02-01", returning="had_basic_respiratory_support",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["icu"] for i in results] == ["1", "1", "0", "0", "0"]
+
+    study = StudyDefinition(
+        population=patients.all(),
+        icu=patients.admitted_to_icu(
+            on_or_after="2020-02-01", returning="had_advanced_respiratory_support",
+        ),
+    )
+    results = study.to_dicts()
+    assert [i["icu"] for i in results] == ["1", "0", "0", "0", "1"]
 
 
 def test_patients_with_these_codes_on_death_certificate():


### PR DESCRIPTION
We have decided to ignore the value of the `Ventilator` column as we don't trust it. See discussion at:
https://github.com/opensafely/cohort-extractor/issues/275#issuecomment-685684964

Instead we use the counts for days of basic and advanced respiratory support (exact meaning of these tbc with ICNARC).

Returning options are now: `had_basic_respiratory_support`, `has_advanced_respiratory_support` and `had_respiratory_support` (which covers either case).

Closes #275

BREAKING CHANGE:
 1. Previously non-ventilated patients were excluded entirely from ICU results
 2. The `was_ventilated` returning option has been removed.
