### PR TITLE
Fixes for `cohortextractor --version`

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -65,6 +65,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+    - name: Generate correct value for VERSION file
+      run: |
+        echo ${{ needs.tag-new-version.outputs.tag }} > cohortextractor/VERSION
     - name: Build and publish to docker registry
       uses: whoan/docker-build-with-cache-action@v5
       with:

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -245,16 +245,23 @@ def load_study_definition(name):
     return importlib.import_module(name).study
 
 
-def list_study_definitions():
+def list_study_definitions(ignore_errors=False):
     pattern = re.compile(r"^(study_definition(_\w+)?)\.py$")
     matches = []
-    for name in sorted(os.listdir(os.path.join(relative_dir(), "analysis"))):
+    try:
+        analysis_files = os.listdir(os.path.join(relative_dir(), "analysis"))
+    except OSError:
+        if not ignore_errors:
+            raise
+        else:
+            analysis_files = []
+    for name in sorted(analysis_files):
         match = pattern.match(name)
         if match:
             name = match.group(1)
             suffix = match.group(2) or ""
             matches.append((name, suffix))
-    if not matches:
+    if not matches and not ignore_errors:
         raise RuntimeError(f"No study definitions found in {relative_dir()}")
     return matches
 
@@ -362,7 +369,7 @@ def main():
         "--study-definition",
         help="Study definition to use",
         type=str,
-        choices=["all"] + [x[0] for x in list_study_definitions()],
+        choices=["all"] + [x[0] for x in list_study_definitions(ignore_errors=True)],
         default="all",
     )
     generate_cohort_parser.add_argument(

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -281,8 +281,8 @@ def admitted_to_icu(
         binary_flag: Whether patient attended A&E
         date_admitted: Date patient arrived in A&E
         had_respiratory_support: Whether patient received any form of respiratory support
-        had_basic_respiratory_support": Whether patient received "basic" respiratory support
-        had_advanced_respiratory_support": Whether patient received "advanced" respiratory support
+        had_basic_respiratory_support: Whether patient received "basic" respiratory support
+        had_advanced_respiratory_support: Whether patient received "advanced" respiratory support
 
         (Note that the terms "basic" and "advanced" are derived from the underlying ICNARC data.)
     """

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2148,9 +2148,7 @@ def test_patients_household_as_of():
         household_size=patients.household_as_of(
             "2020-02-01", returning="household_size"
         ),
-        is_prison=patients.household_as_of(
-            "2020-02-01", returning="is_prison"
-        ),
+        is_prison=patients.household_as_of("2020-02-01", returning="is_prison"),
     )
     results = study.to_dicts()
     assert [x["household_id"] for x in results] == ["0", "123", "456", "0"]


### PR DESCRIPTION
This fixes two issues:
 * It was impossible to display the cohortextractor version number without
   having a study_definition file in the right place.
 * The version number was not included in Docker builds.