### PR TITLE
Fix transaction handling

### DIFF
--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -79,6 +79,7 @@ def _ctds_connect(ctds, params):
     # Default timeout is 5 seconds. We don't want queries to timeout at all so
     # set to one week
     params["timeout"] = 7 * 24 * 60 * 60
+    params["autocommit"] = True
     return ctds.connect(**params)
 
 

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -922,7 +922,9 @@ def test_patients_registered_practice_as_of(freezer):
         StudyDefinition(
             population=patients.all(),
             stp=patients.registered_practice_as_of("2020-02-01", returning="stp_code"),
-            msoa=patients.registered_practice_as_of("2020-02-01", returning="msoa_code"),
+            msoa=patients.registered_practice_as_of(
+                "2020-02-01", returning="msoa_code"
+            ),
             region=patients.registered_practice_as_of(
                 "2020-02-01", returning="nuts1_region_name"
             ),


### PR DESCRIPTION
pyODBC and cTDS have quite different ideas about transaction management:
https://github.com/mkleehammer/pyodbc/wiki/Database-Transaction-Management
https://zillow.github.io/ctds/transactions.html

I had managed not to notice the bug here because the "happy path" for using temporary tables (where the download works first time and the temporary table can be immediately deleted) wasn't previously tested.