### PR TITLE
Fixes to measure framework

### DIFF
--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -156,6 +156,11 @@ study = StudyDefinition(
 
 measures = [
     Measure(
+        id="liver_disease",
+        numerator="has_chronic_liver_disease",
+        denominator="population",
+    ),
+    Measure(
         id="liver_disease_by_stp",
         numerator="has_chronic_liver_disease",
         denominator="population",

--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -995,6 +995,11 @@ class EMISBackend:
         self._db_connection = presto_connection_from_url(self.database_url)
         return self._db_connection
 
+    def close(self):
+        if self._db_connection:
+            self._db_connection.close()
+        self._db_connection = None
+
     def validate_recent_date(self, date, max_delta_days=30):
         date = datetime.datetime.strptime(date, "%Y-%m-%d").date()
         delta = datetime.date.today() - date

--- a/cohortextractor/measure.py
+++ b/cohortextractor/measure.py
@@ -1,5 +1,5 @@
 class Measure:
-    def __init__(self, id, denominator, numerator, group_by):
+    def __init__(self, id, denominator, numerator, group_by=None):
         self.id = id
         self.denominator = denominator
         self.numerator = numerator

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -186,6 +186,17 @@ class TPPBackend:
             else:
                 raise
 
+    def get_db_connection(self):
+        if self._db_connection:
+            return self._db_connection
+        self._db_connection = mssql_dbapi_connection_from_url(self.database_url)
+        return self._db_connection
+
+    def close(self):
+        if self._db_connection:
+            self._db_connection.close()
+        self._db_connection = None
+
     def get_queries(self, covariate_definitions):
         output_columns = {}
         column_types = {}
@@ -1698,12 +1709,6 @@ class TPPBackend:
             f" WHERE value != {default_value}"
         )
         return f"ISNULL(({aggregate_expression}), {default_value})"
-
-    def get_db_connection(self):
-        if self._db_connection:
-            return self._db_connection
-        self._db_connection = mssql_dbapi_connection_from_url(self.database_url)
-        return self._db_connection
 
 
 def codelist_to_sql(codelist):

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -32,6 +32,14 @@ def test_smoketest(tmp_path):
     assert len(contents) == 1 + (2 * 4)  # Header row + 2 STPs * 4 dates
     dates = set(row[4] for row in contents[1:])
     assert dates == {"2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"}
+    with open(tmp_path / "measure_liver_disease.csv") as f:
+        contents = list(csv.reader(f))
+    assert contents[0] == [
+        "has_chronic_liver_disease",
+        "population",
+        "value",
+        "date",
+    ]
 
 
 def _cohortextractor(*args):


### PR DESCRIPTION
 * **Reinitialise backend when changing index date**
   This is obviously necessary but didn't get spotted before because the
   tests use the dummy data generator.

 * **Ignore files without dates in the names**
   Previously, if there was an `input.csv` file present it would cause the
   `generate_measures` command to throw an error.

 * **Support not setting `group_by`**
    This is equivalent to "group everything"

Fixes #299 and addresses some of the issues raised in https://github.com/opensafely/cohort-extractor/pull/269#issuecomment-696046829