### PR TITLE
Improve performance of "not on same day" queries

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -28,6 +28,7 @@ class TPPBackend:
         self.covariate_definitions = covariate_definitions
         self.temporary_database = temporary_database
         self.codelist_tables = []
+        self.next_table_id = 1
         self.queries = self.get_queries(self.covariate_definitions)
 
     def to_csv(self, filename):
@@ -333,11 +334,7 @@ class TPPBackend:
         return return_value
 
     def create_codelist_table(self, codelist, case_sensitive=True):
-        table_number = len(self.codelist_tables) + 1
-        # We include the current column name for ease of debugging
-        column_name = self._current_column_name or "unknown"
-        # The hash prefix indicates a temporary table
-        table_name = f"#codelist_{table_number}_{column_name}"
+        table_name = self.get_temp_table_name("codelist")
         if codelist.has_categories:
             values = list(codelist)
         else:
@@ -359,6 +356,16 @@ class TPPBackend:
                 values,
             )
         )
+        return table_name
+
+    def get_temp_table_name(self, suffix):
+        # The hash prefix indicates a temporary table
+        table_name = f"#tmp{self.next_table_id}_"
+        self.next_table_id += 1
+        # We include the current column name if available for ease of debugging
+        if self._current_column_name:
+            table_name += f"{self._current_column_name}_"
+        table_name += suffix
         return table_name
 
     def get_codelist_queries(self):

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -236,9 +236,9 @@ class TPPBackend:
                 )
             else:
                 date_format_args = pop_keys_from_dict(query_args, ["date_format"])
-                cols, sql, setup_sql = self.get_query(name, query_type, query_args)
+                cols, sql, setup_queries = self.get_query(name, query_type, query_args)
                 table_queries[name] = f"SELECT * INTO #{name} FROM ({sql}) t"
-                table_setup_queries[name] = setup_sql
+                table_setup_queries[name] = setup_queries
                 # The first column should always be patient_id so we can join on it
                 assert cols[0] == "patient_id"
                 output_columns[name] = self.get_column_expression(
@@ -918,8 +918,10 @@ class TPPBackend:
     def _these_codes_occur_on_same_day(self, joined_table, codelist, date_condition):
         """
         Generates a SQL condition that filters rows in `joined_table` so that
-        they only include events which happened on days where none of the codes
-        in `codelist` occur in the CodedEvents table.
+        they only include events which happened on days where one of the codes
+        in `codelist` occur in the CodedEvents table. Usually we negate this
+        condition in the surrounding query so that we only includes days where
+        *none* of the codes occured.
 
         We use this to support queries like "give me all the times a patient
         was prescribed this drug, but ignore any days on which they were having


### PR DESCRIPTION
This PR improves the performance of queries which use the `ignore_days_where_these_codes_occur` option. It does this by creating a temporary table with an index on it, and then using that in the subquery rather than the enormous `CodedEvent` table.

This requires some refactoring to support creating arbitrary temporary tables. The handling of codelist tables could be subsumed into this which would simplify things but we leave that refactor for another day.

Closes #302