### PR TITLE
Add ORDER BY clauses to make results deterministic

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -465,7 +465,9 @@ class TPPBackend:
         SELECT t.Patient_ID, t.BMI, t.ConsultationDate
         FROM (
           SELECT Patient_ID, NumericValue AS BMI, ConsultationDate,
-          ROW_NUMBER() OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate DESC) AS rownum
+          ROW_NUMBER() OVER (
+            PARTITION BY Patient_ID ORDER BY ConsultationDate DESC, CodedEvent_ID
+          ) AS rownum
           FROM CodedEvent
           WHERE CTV3Code = {quote(bmi_code)} AND {date_condition}
         ) t
@@ -481,7 +483,9 @@ class TPPBackend:
           SELECT t.Patient_ID, t.weight, t.ConsultationDate
           FROM (
             SELECT Patient_ID, NumericValue AS weight, ConsultationDate,
-            ROW_NUMBER() OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate DESC) AS rownum
+              ROW_NUMBER() OVER (
+                PARTITION BY Patient_ID ORDER BY ConsultationDate DESC, CodedEvent_ID
+              ) AS rownum
             FROM CodedEvent
             WHERE CTV3Code IN ({weight_codes_sql}) AND {date_condition}
           ) t
@@ -499,7 +503,9 @@ class TPPBackend:
           SELECT t.Patient_ID, t.height, t.ConsultationDate
           FROM (
             SELECT Patient_ID, NumericValue AS height, ConsultationDate,
-            ROW_NUMBER() OVER (PARTITION BY Patient_ID ORDER BY ConsultationDate DESC) AS rownum
+            ROW_NUMBER() OVER (
+              PARTITION BY Patient_ID ORDER BY ConsultationDate DESC, CodedEvent_ID
+            ) AS rownum
             FROM CodedEvent
             WHERE CTV3Code IN ({height_codes_sql}) AND {height_date_condition}
           ) t
@@ -737,7 +743,8 @@ class TPPBackend:
             FROM (
               SELECT Patient_ID, {column_definition}, ConsultationDate,
               ROW_NUMBER() OVER (
-                PARTITION BY Patient_ID ORDER BY ConsultationDate {ordering}
+                PARTITION BY Patient_ID
+                ORDER BY ConsultationDate {ordering}, {from_table}_ID
               ) AS rownum
               FROM {from_table}{additional_join}
               INNER JOIN {codelist_table}
@@ -931,7 +938,8 @@ class TPPBackend:
         FROM (
           SELECT Patient_ID, Organisation_ID,
           ROW_NUMBER() OVER (
-            PARTITION BY Patient_ID ORDER BY StartDate DESC, EndDate DESC
+            PARTITION BY Patient_ID
+            ORDER BY StartDate DESC, EndDate DESC, Registration_ID
           ) AS rownum
           FROM RegistrationHistory
           WHERE StartDate <= {quote(date)} AND EndDate > {quote(date)}
@@ -993,7 +1001,8 @@ class TPPBackend:
         FROM (
           SELECT Patient_ID, {column},
           ROW_NUMBER() OVER (
-            PARTITION BY Patient_ID ORDER BY StartDate DESC, EndDate DESC
+            PARTITION BY Patient_ID
+            ORDER BY StartDate DESC, EndDate DESC, PatientAddress_ID
           ) AS rownum
           FROM PatientAddress
           WHERE StartDate <= {quote(date)} AND EndDate > {quote(date)}
@@ -1028,7 +1037,8 @@ class TPPBackend:
             LocationRequiresNursing,
             LocationDoesNotRequireNursing,
             ROW_NUMBER() OVER (
-              PARTITION BY PatientAddress.Patient_ID ORDER BY StartDate DESC, EndDate DESC
+              PARTITION BY PatientAddress.Patient_ID
+              ORDER BY StartDate DESC, EndDate DESC, PatientAddress.PatientAddress_ID
             ) AS rownum
           FROM PatientAddress
           LEFT JOIN PotentialCareHomeAddress
@@ -1445,6 +1455,13 @@ class TPPBackend:
         conditions = " AND ".join(conditions)
 
         if use_partition_query:
+            # Note EC_Ident is not guaranteed unique by the database but I
+            # suspect it is intended to be unique by the source. Out of ~20m
+            # rows currently there are only two duplicate EC_Idents and these
+            # are for rows identical in all respects apart from Patient_ID.
+            # Thus while using EC_Ident as the final sort column below doesn't
+            # absolutely *guaranteee* a deterministic sort order, I think it's
+            # good enough.
             sql = f"""
             SELECT
               Patient_ID AS patient_id,
@@ -1452,7 +1469,8 @@ class TPPBackend:
             FROM (
               SELECT EC.Patient_ID, {column},
               ROW_NUMBER() OVER (
-                PARTITION BY EC.Patient_ID ORDER BY Arrival_Date {ordering}
+                PARTITION BY EC.Patient_ID
+                ORDER BY Arrival_Date {ordering}, EC.EC_Ident
               ) AS rownum
               FROM EC
               INNER JOIN EC_Diagnosis
@@ -1532,6 +1550,14 @@ class TPPBackend:
         conditions = " AND ".join(conditions)
 
         if use_partition_query:
+            # Note APCS_Ident is not guaranteed unique by the database but I
+            # suspect it is intended to be unique by the source. For one thing,
+            # it seems to be used as a foreign key in the other ACDS tables.
+            # And out of ~3.5m rows currently there are only four duplicate
+            # APCS_Idents and these are for rows identical in all respects
+            # apart from Patient_ID.  Thus while using APCS_Ident as the final
+            # sort column below doesn't absolutely *guaranteee* a deterministic
+            # sort order, I think it's good enough.
             sql = f"""
             SELECT
               Patient_ID AS patient_id,
@@ -1539,7 +1565,8 @@ class TPPBackend:
             FROM (
               SELECT APCS.Patient_ID, {column},
               ROW_NUMBER() OVER (
-                PARTITION BY APCS.Patient_ID ORDER BY Admission_Date {ordering}
+                PARTITION BY APCS.Patient_ID
+                ORDER BY Admission_Date {ordering}, APCS.APCS_Ident
               ) AS rownum
               FROM APCS
               INNER JOIN APCS_Der

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1047,6 +1047,24 @@ def test_patients_address_as_of():
                     ),
                 ]
             ),
+            Patient(
+                Addresses=[
+                    PatientAddress(
+                        StartDate="1900-01-01",
+                        EndDate="9999-12-31",
+                        ImdRankRounded=-1,
+                        RuralUrbanClassificationCode=-1,
+                        MSOACode="NPC",
+                    ),
+                    PatientAddress(
+                        StartDate="1900-01-01",
+                        EndDate="9999-12-31",
+                        ImdRankRounded=600,
+                        RuralUrbanClassificationCode=4,
+                        MSOACode="E02002346",
+                    ),
+                ]
+            ),
             # Patient with no address
             Patient(),
             # Patient with only old address
@@ -1075,7 +1093,7 @@ def test_patients_address_as_of():
         ),
     )
     assert_results(
-        study.to_dicts(), imd=["300", "0", "0"], rural_urban=["2", "0", "0"],
+        study.to_dicts(), imd=["300", "600", "0", "0"], rural_urban=["2", "4", "0", "0"]
     )
 
 


### PR DESCRIPTION
In certain cases where we use the `ROWNUMBER() OVER (PARTITION BY ..`
`ORDER BY .. )` pattern to select only the first matching row in a join,
we don't specify enough order conditions to uniquely determine a first
row. When this happens the result is arbitrary (which is sort of OK) and
non-deterministic (which is not OK). This patch attempts to fix the
non-determinism by adding a tie-breaker column to the end of the sort
conditions, which is usually the ID field of the table in question.

There are two cases (the EC and APCS tables) where we can't 100%
guarantee determinstic ordering because this are no fields with a unique
constraint. However in both cases there is an "ident" field which is
almost entirely unique and where the tiny handful of duplicates are
otherwise identical and so shouldn't result in non-deterministic outputs
anyway.

This ought to fix the issue identified in #297 although I haven't yet
confirmed this.

Note that while this fixes the non-determinism it doesn't address the
arbitrariness. That is, where we have multiple matches there might be
better reasons for choosing one result over another, or better ways of
combining those results together as in the case of BMI.
