### PR TITLE
Better codelist handling in APCS/EC methods

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1455,13 +1455,15 @@ class TPPBackend:
 
         if with_these_diagnoses:
             assert isinstance(with_these_diagnoses, list)
-            codes = ", ".join(f"'{code}'" for code in with_these_diagnoses)
+            assert isinstance(with_these_diagnoses[0], str)
+            codes = ", ".join(map(quote, with_these_diagnoses))
             fragments = [f"EC_Diagnosis_{ix:02} IN ({codes})" for ix in range(1, 25)]
             conditions.append("(" + " OR ".join(fragments) + ")")
 
         if discharged_to:
             assert isinstance(discharged_to, list)
-            codes = ", ".join(f"'{code}'" for code in discharged_to)
+            assert isinstance(discharged_to[0], str)
+            codes = ", ".join(map(quote, discharged_to))
             conditions.append(f"Discharge_Destination_SNOMED_CT IN ({codes})")
 
         conditions = " AND ".join(conditions)

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2501,12 +2501,12 @@ def test_patients_admitted_to_hospital():
         with_particular_primary_diagnosis=patients.admitted_to_hospital(
             on_or_after="2020-02-01",
             returning="binary_flag",
-            with_these_primary_diagnoses=codelist(["EEEE"], "icd10"),
+            with_these_primary_diagnoses=codelist([("EEEE", "cat1")], "icd10"),
         ),
         with_particular_diagnoses_1=patients.admitted_to_hospital(
             on_or_after="2020-02-01",
             returning="number_of_matches_in_period",
-            with_these_diagnoses=codelist(["XXXD"], "icd10"),
+            with_these_diagnoses=codelist([("XXXD", "cat2")], "icd10"),
         ),
         with_particular_diagnoses_2=patients.admitted_to_hospital(
             on_or_after="2020-02-01",

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2158,7 +2158,7 @@ def test_patients_household_as_of():
         )
 
 
-def test_patients_attended_accident_and_emergency():
+def test_patients_attended_emergency_care():
     discharge_to_ward = "306706006"
     discharge_to_home = "306689006"
     covid_19 = "1240751000000100"


### PR DESCRIPTION
These methods did their own codelist-to-SQL conversion meaning that they didn't handle categorised codelists correctly.

Fixes #317