### PR TITLE
feat: Support returning `Household.TppPercentage` column

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -586,6 +586,12 @@ def household_as_of(reference_date, returning=None, return_expectations=None):
                                           different EHR system, meaning that our
                                           coverage of the household is incomplete.
 
+        percentage_of_members_with_ehr_data_available: Integer giving the (estimated)
+                                                       percentage of household members
+                                                       where we have EHR data available
+                                                       (i.e. not in other systems as
+                                                       above)
+
         msoa: Returns the MSOA (Middle Super Output Area) in which the household is
               situated
 

--- a/cohortextractor/process_covariate_definitions.py
+++ b/cohortextractor/process_covariate_definitions.py
@@ -341,6 +341,7 @@ class GetColumnType:
             "primary_diagnosis": "str",
             "is_prison": "bool",
             "has_members_in_other_ehr_systems": "bool",
+            "percentage_of_members_with_ehr_data_available": "int",
             "msoa": "str",
         }
         try:

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1406,6 +1406,8 @@ class TPPBackend:
             column = (
                 "CASE Household.MixedSoftwareHousehold WHEN 'TRUE' THEN 1 ELSE 0 END"
             )
+        elif returning == "percentage_of_members_with_ehr_data_available":
+            column = "Household.TppPercentage"
         elif returning == "msoa":
             column = "Household.MSOA"
         else:

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2093,6 +2093,7 @@ def test_patients_household_as_of():
                             HouseholdSize=2,
                             Prison=True,
                             MixedSoftwareHousehold=False,
+                            TppPercentage=100,
                             MSOA="S02001286",
                         )
                     )
@@ -2105,6 +2106,7 @@ def test_patients_household_as_of():
                             Household_ID=456,
                             HouseholdSize=3,
                             Prison=False,
+                            TppPercentage=66,
                             MixedSoftwareHousehold=True,
                             MSOA="S02001354",
                         )
@@ -2121,6 +2123,7 @@ def test_patients_household_as_of():
                             HouseholdSize=4,
                             NFA_Unknown=True,
                             Prison=False,
+                            TppPercentage=100,
                             MixedSoftwareHousehold=False,
                             MSOA="S02001781",
                         )
@@ -2140,6 +2143,9 @@ def test_patients_household_as_of():
         mixed_ehr=patients.household_as_of(
             "2020-02-01", returning="has_members_in_other_ehr_systems"
         ),
+        percent_tpp=patients.household_as_of(
+            "2020-02-01", returning="percentage_of_members_with_ehr_data_available"
+        ),
         msoa=patients.household_as_of("2020-02-01", returning="msoa"),
     )
     assert_results(
@@ -2148,6 +2154,7 @@ def test_patients_household_as_of():
         household_size=["0", "2", "3", "0"],
         is_prison=["0", "1", "0", "0"],
         mixed_ehr=["0", "0", "1", "0"],
+        percent_tpp=["0", "100", "66", "0"],
         msoa=["", "S02001286", "S02001354", ""],
     )
     # We currently only accept one specific date

--- a/tests/tpp_backend_setup.py
+++ b/tests/tpp_backend_setup.py
@@ -410,6 +410,7 @@ class Household(Base):
     # CareHome (boolean) - not currently being used
     Prison = Column(Boolean)
     MixedSoftwareHousehold = Column(Boolean)
+    TppPercentage = Column(Integer)
     HouseholdSize = Column(Integer)
     MSOA = Column(String)
     HouseholdMembers = relationship(


### PR DESCRIPTION
This is accessed via the slightly verbose option name:
percentage_of_members_with_ehr_data_available

This means it can be used across other EHR systems and is hopefully
self-explanatory to someone encountering it in a study definition for
the first time.

Example:
```
percent_tpp=patients.household_as_of(
    "2020-02-01", returning="percentage_of_members_with_ehr_data_available"
),
```

Closes #313