### PR TITLE
Use batched downloads to work around "EOF" issue

### DIFF
--- a/cohortextractor/mssql_utils.py
+++ b/cohortextractor/mssql_utils.py
@@ -92,28 +92,6 @@ def mssql_sqlalchemy_engine_from_url(url):
     return sqlalchemy.create_engine(URL(**params))
 
 
-def dbapi_cursor_to_csv_file(cursor, filename, batch_size=None, row_callback=None):
-    """
-    Takes a DB-API comptabile cursor object with a result set and writes those
-    results to a CSV file, calling `row_callback` (if defined) on each row as
-    it does so
-    """
-    if batch_size is None:
-        batch_size = cursor.arraysize
-    if row_callback is None:
-        row_callback = lambda x: None
-    with open(filename, "w", newline="") as csvfile:
-        writer = csv.writer(csvfile)
-        writer.writerow([x[0] for x in cursor.description])
-        while True:
-            result_batch = cursor.fetchmany(batch_size)
-            if not result_batch:
-                break
-            for row in result_batch:
-                writer.writerow(row)
-                row_callback(row)
-
-
 def mssql_table_to_csv(
     filename,
     cursor,

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -49,8 +49,10 @@ class TPPBackend:
         temp_filename = self._get_temp_filename(filename)
         unique_check = UniqueCheck()
 
-        def record_patient_id(row):
+        def record_patient_id_and_log(row):
             unique_check.add(row[0])
+            if unique_check.count % 1000000 == 0:
+                self.log(f"Downloaded {unique_check.count} results")
 
         # `batch_size` here was chosen through a bit of unscientific
         # trial-and-error and some guesswork. It may well need changing in
@@ -61,10 +63,11 @@ class TPPBackend:
             table=output_table,
             key_column="patient_id",
             batch_size=32000,
-            row_callback=record_patient_id,
+            row_callback=record_patient_id_and_log,
             retries=2,
             sleep=0.5,
         )
+        self.log(f"Downloaded {unique_check.count} results")
 
         self.execute_queries(
             [f"-- Deleting '{output_table}'\nDROP TABLE {output_table}"]


### PR DESCRIPTION
This PR uses a different approach to downloading results to try to work around the "EOF from server" error which has been occurring more frequently. We now download results in small batches which should (we think) be less likely to trigger the error and (more importantly) can be automatically retried if they fail so the user shouldn't have to do anything special to handle these errors.