### PR TITLE
Trial of google-style docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ model.log
 __pycache__
 .python-version
 outputs/*
+.idea

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -20,7 +20,7 @@ def random_sample(percent=None, return_expectations=None):
         return_expectations: a dict containing an expectations definition defining at least an `incidence`
 
     Returns:
-        list: zeros and ones
+        list: of integers of `1` or `0`
 
     Example:
         This creates a variable `example`, flagging approximately 10% of the population with the value `1`:
@@ -103,7 +103,7 @@ def date_of_birth(
         list: dates as strings with "YYYY-MM" format
 
     Raises:
-        ValueError: if Date of Birth is attempted to be returned with a YYYY-MM-DD format.
+        ValueError: if Date of Birth is attempted to be returned with a `YYYY-MM-DD` format.
 
     Example:
 
@@ -277,8 +277,8 @@ def most_recent_bmi(
             a BMI. It needs to be a number between 0 and 1.
         include_measurement_date: a boolean indicating if an extra column, named `date_of_bmi`,
             should be included in the output. The default value is `False`.
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
             include_measurement_date is `True`
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
@@ -352,8 +352,8 @@ def mean_recorded_value(
             Filters results to measurements between the two dates provided. The default value is `None`.
         include_measurement_date: a boolean indicating if an extra column, named `date_of_bmi`,
             should be included in the output. The default value is `False`.
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
             include_measurement_date is `True`
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
@@ -443,15 +443,15 @@ def with_these_medications(
             `last_date_in_period`. The default value is `binary_flag`.
         include_date_of_match: a boolean indicating if an extra column, should be included in the output.
             The default value is `False`.
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if include_date_of_match
             is `True`
         ignore_days_where_these_clinical_codes_occur: a codelist that contains codes for medications to be
             ignored. if a medication is found on this day, the date is not matched even it matches a
             code in the main `codelist`
         episode_defined_as: a string expression indicating how an episode should be defined
-        return_binary_flag=None,
+        return_binary_flag: a bool indicatin if a binary flag should be returned (deprecated: use `date_format` instead)
         return_number_of_matches_in_period: a boolean indicating if the number of matches in a period should be
             returned (deprecated: use `date_format` instead)
         return_first_date_in_period: a boolean indicating if the first matches in a period should be
@@ -544,8 +544,8 @@ def with_these_clinical_events(
             `last_date_in_period`. The default value is `binary_flag`.
         include_date_of_match: a boolean indicating if an extra column, should be included in the output.
             The default value is `False`.
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if include_date_of_match
             is `True`
         ignore_days_where_these_codes_occur: a codelist that contains codes for events to be
@@ -838,9 +838,9 @@ def admitted_to_icu(
     Return information about being admitted to ICU.
 
     Args:
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
         find_first_match_in_period: a boolean that indicates if the data returned is first admission to icu if
@@ -854,8 +854,8 @@ def admitted_to_icu(
             had_basic_respiratory_support: Whether patient received "basic" respiratory support
             had_advanced_respiratory_support: Whether patient received "advanced" respiratory support
             (Note that the terms "basic" and "advanced" are derived from the underlying ICNARC data.)
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
             `returning` is `binary_flag`
         return_expectations: a dictionary defining the incidence and distribution of expected value
@@ -920,19 +920,19 @@ def with_these_codes_on_death_certificate(
 
     Args:
         codelist: a codelist for requested value
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results between the two dates provided. The default value is `None`.
         match_only_underlying_cause: boolean for indicating if filters results to only specified cause of death.
         returning: a string indicating what type of value should be returned. The options are:
            date_of_death: Date of death
            binary_flag: If they died or not
            underlying_cause_of_death: The icd10 code corresponding to the underlying cause of death
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
             `date_format` instead).
@@ -978,17 +978,17 @@ def died_from_any_cause(
     Identify patients who with ONS-registered deaths
 
     Args:
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results to between the two dates provided. The default value is `None`.
         returning: a string indicating what type of value should be returned. The options are:
            date_of_death: Date of death
             binary_flag: If they died or not
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
             `date_format` instead).
@@ -1035,17 +1035,17 @@ def with_death_recorded_in_cpns(
     Identify patients who with death registered in CPNS dataset
 
     Args:
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results to between the two dates provided. The default value is `None`.
         returning: a string indicating what type of value should be returned. The options are:
             date_of_death: Date of death
             binary_flag: If they died or not
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
             `date_format` instead).
@@ -1095,17 +1095,17 @@ def with_death_recorded_in_primary_care(
     in the primary care record so we don't make it available to query here.
 
         Args:
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results to  between the two dates provided. The default value is `None`.
         returning: a string indicating what type of value should be returned. The options are:
             date_of_death: Date of death
             binary_flag: If they died or not
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         return_expectations: a dictionary defining the incidence and distribution of expected value
             within the population in question.
@@ -1164,16 +1164,16 @@ def with_tpp_vaccination_record(
     Args:
         target_disease_matches: the target disease as a string
         product_name_matches: the product name as a string
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results to between the two dates provided. The default value is `None`.
         returning: a string indicating what type of value should be returned. The options are limited to binary_flag
             (which indicates if they have had the vaccination or not) or a date of vaccination
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         find_first_match_in_period: a boolean that indicates if the data returned is first indication of vaccination
             if there are multiple matches within the time period
@@ -1226,12 +1226,12 @@ def with_gp_consultations(
     receptionist.
 
     Args:
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results to between the two dates provided. The default value is `None`.
         find_first_match_in_period: a boolean that indicates if the data returned is first event
             if there are multiple matches within the time period
         find_last_match_in_period: a boolean that indicates if the data returned is last event
@@ -1240,8 +1240,8 @@ def with_gp_consultations(
             (which indicates if they have had the an event or not), date (which indicate date of event and used
             with either find_first_match_in_period or find_last_match_in_period), or number_of_matches_in_period
             (which counts the events in the period)
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         return_expectations: a dictionary defining the incidence and distribution of expected value
             within the population in question.
@@ -1354,12 +1354,12 @@ def with_test_result_in_sgss(
             will throw an error if the specified pathogen is anything other than
             "SARS-CoV-2".
         test_result: must be one of "positive", "negative" or "any"
-        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
             on or before the given date.The default value is `None`.
-        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is `None`.
+            Filters results to between the two dates provided. The default value is `None`.
         find_first_match_in_period: a boolean that indicates if the data returned is first event
             if there are multiple matches within the time period
         find_last_match_in_period: a boolean that indicates if the data returned is last event
@@ -1367,8 +1367,8 @@ def with_test_result_in_sgss(
         returning: a string indicating what type of value should be returned. The options are limited to binary_flag
             (which indicates if they have had the an event or not) and date (which indicate date of event and used
             with either find_first_match_in_period or find_last_match_in_period)
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         return_expectations: a dictionary defining the incidence and distribution of expected value
             within the population in question.
@@ -1536,8 +1536,8 @@ def attended_emergency_care(
             if there are multiple matches within the time period
         find_last_match_in_period: a boolean that indicates if the data returned is last event
             if there are multiple matches within the time period
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         with_these_diagnoses: a list of SNOMED CT codes
         discharged_to:a list of members of refset 999003011000000105.
@@ -1588,8 +1588,8 @@ def date_deregistered_from_all_supported_practices(
             on or after the given date.The default value is `None`.
         between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
             Filters results to between the two dates provided. The default value is `None`.
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         return_expectations: a dictionary defining the incidence and distribution of expected value
             within the population in question.
@@ -1648,8 +1648,8 @@ def admitted_to_hospital(
             if there are multiple matches within the time period
         find_last_match_in_period: a boolean that indicates if the data returned is last event
             if there are multiple matches within the time period
-        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
-            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+        date_format: a string detailing the format of the dates to be returned. It can be `YYYY-MM-DD`,
+            `YYYY-MM` or `YYYY` and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year.
         with_these_diagnoses: icd10 codes to match against any diagnosis
         with_these_primary_diagnoses: icd10 codes to match against the primary diagnosis

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1,8 +1,11 @@
-""" This module provides the methods for making a study definition """
-# These methods don't *do* anything; they just return their name and arguments.
-# This provides a friendlier API than having to build some big nested data
-# structure by hand and means we can make use of autocomplete, docstrings etc to
-# make it a bit more discoverable.
+"""
+This module provides the methods for making a study definition
+
+These methods don't *do* anything; they just return their name and arguments.
+This provides a friendlier API than having to build some big nested data
+structure by hand and means we can make use of autocomplete, docstrings etc to
+make it a bit more discoverable.
+"""
 
 # Yes this clashes with the builtin, but we don't need the builtin in this
 # context

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -23,9 +23,9 @@ def random_sample(percent=None, return_expectations=None):
         list: zeros and ones
 
     Example:
-        This creates a variable `training_set`, flagging approximately 10% of the population with the value `1`:
+        This creates a variable `example`, flagging approximately 10% of the population with the value `1`:
 
-            training_set=patients.random_sample(percent=10, expectations={'incidence': 0.1})
+            example=patients.random_sample(percent=10, expectations={'incidence': 0.1})
 
     """
     return "random_sample", locals()
@@ -34,6 +34,21 @@ def random_sample(percent=None, return_expectations=None):
 def sex(return_expectations=None):
     """
     Returns M, F or empty string if unknown or other
+
+    Args:
+         return_expectations (dict): An expectation definition defining a rate and a ratio (dict) for
+            sexes
+
+    Returns:
+        list: "M", "F" or ""
+
+    Example:
+        This creates a variable 'sex' with all patients returning a sex of either "M", "F" or ""
+
+            sex=patients.sex(return_expectations={
+                                "rate": "universal",
+                                "category": {"ratios": {"M": 0.49, "F": 0.51}},
+                            }
 
     """
     return "sex", locals()
@@ -44,6 +59,29 @@ def age_as_of(
     # Required keyword
     return_expectations=None,
 ):
+    """
+    Returns age of patient of at a particular date
+
+    Args:
+        reference_date (str): date string in format of "YYYY-MM-DD"
+        return_expectations(dict): An expectation definition defining a rate and a distribution (as a dict). If this
+            is put as "population_ages" it returns likely distribution based on known UK age bands in 2018 (see file:
+            "uk_population_bands_2018.csv"
+
+    Returns:
+        list: Ages as integers
+
+    Examples:
+        This creates a variable "age" with all patient returning an age as an integer:
+
+            age=patients.age_as_of(
+                "2020-02-01",
+                return_expectations={
+                    "rate" : "universal",
+                    "int" : {"distribution" : "population_ages"}
+                },
+
+    """
     return "age_as_of", locals()
 
 
@@ -52,10 +90,31 @@ def date_of_birth(
     # Required keyword
     return_expectations=None,
 ):
+    """
+    Returns date of birth as a string with format "YYYY-MM"
+
+    Args:
+        date_format (str, None): "YYYY-MM", "YYYY" format or None
+        return_expectations (dict, None): An expectation definition defining a rate and a distribution (as a dict)
+
+    Returns:
+        list: Dates as strings with "YYYY-MM" format
+
+    Raises:
+        ValueError: If Date of Birth is attempted to be returned with a YYYY-MM-DD format.
+
+    Example:
+        dob=patients.date_of_birth(
+            "YYYY-MM",
+            return_expectations={ TODO: find out about this!!
+                }
+    """
+
     # The actual enforcement of this information governance rule is done in the
     # database; this is just to give early warning to the user
     if date_format == "YYYY-MM-DD":
         raise ValueError("Date of birth can only be retrieved to month granularity")
+
     return "date_of_birth", locals()
 
 
@@ -65,7 +124,15 @@ def registered_as_of(
     return_expectations=None,
 ):
     """
-    All patients registed on the given date
+    All patients registered on the given date. This functions passes arguments
+    to registered_with_one_practice_between()
+
+    Args:
+        reference_date (str): date in format of YYYY-MM-DD
+
+    Returns:
+        list: Ones (as ints)
+
     """
     return "registered_as_of", locals()
 

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1072,7 +1072,6 @@ def with_death_recorded_in_cpns(
                 "rate" : "exponential_increase"},
             ),
     """
-
     return "with_death_recorded_in_cpns", locals()
 
 

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -16,8 +16,8 @@ def random_sample(percent=None, return_expectations=None):
     Flags a random sample of approximately `percent` patients.
 
     Args:
-        percent: Number between 1 and 100
-        return_expectations: an expectations definition defining at least an `incidence`
+        percent: an integer between 1 and 100 for the percent of patients to include within the random sample
+        return_expectations: a dict containing an expectations definition defining at least an `incidence`
 
     Returns:
         list: zeros and ones
@@ -36,7 +36,7 @@ def sex(return_expectations=None):
     Returns M, F or empty string if unknown or other
 
     Args:
-         return_expectations (dict): An expectation definition defining a rate and a ratio (dict) for
+         return_expectations: a dict containing an expectation definition defining a rate and a ratio for
             sexes
 
     Returns:
@@ -63,13 +63,13 @@ def age_as_of(
     Returns age of patient of at a particular date
 
     Args:
-        reference_date (str): date string in format of "YYYY-MM-DD"
-        return_expectations(dict): An expectation definition defining a rate and a distribution (as a dict). If this
-            is put as "population_ages" it returns likely distribution based on known UK age bands in 2018 (see file:
-            "uk_population_bands_2018.csv"
+        reference_date: date of interest as a string with the format `YYYY-MM-DD`
+        return_expectations: a dict defining an expectation definition that includes at least a rate
+            and a distribution. If `distribution` is defined as "population_ages" it returns likely distribution
+            based on known UK age bands in 2018 (see file: "uk_population_bands_2018.csv")
 
     Returns:
-        list: Ages as integers
+        list: ages as integers
 
     Example:
         This creates a variable "age" with all patient returning an age as an integer:
@@ -94,18 +94,20 @@ def date_of_birth(
     Returns date of birth as a string with format "YYYY-MM"
 
     Args:
-        date_format (str, None): "YYYY-MM", "YYYY" format or None
-        return_expectations (dict, None): An expectation definition defining a rate and a distribution (as a dict)
+        date_format: a string detailing the format of the dates for date of birth to be returned.
+            It can be "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be
+            returned. i.e returning only year is less disclosive than a date with month and year.
+        return_expectations: a dictionary containing an expectation definition defining a rate and a distribution
 
     Returns:
-        list: Dates as strings with "YYYY-MM" format
+        list: dates as strings with "YYYY-MM" format
 
     Raises:
-        ValueError: If Date of Birth is attempted to be returned with a YYYY-MM-DD format.
+        ValueError: if Date of Birth is attempted to be returned with a YYYY-MM-DD format.
 
     Example:
 
-        This creates a variable "dob" with all patient returning a year and month as a string:
+        This creates a variable `dob` with all patient returning a year and month as a string:
 
             dob=patients.date_of_birth(
                 "YYYY-MM",
@@ -131,16 +133,18 @@ def registered_as_of(
     to registered_with_one_practice_between()
 
     Args:
-        reference_date (str): date in format of YYYY-MM-DD
-        return_expectations (dict, None): An expectation definition defining a rate
+        reference_date: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
+            patients registered at a practice on the given date.
+        return_expectations: a dictionary containing an expectation definition defining an `incidence`
+            between `0` and `1`.
 
     Returns:
-        list: Ones (as ints)
+        list: of integers of `1` or `0`.
 
     Example:
 
-        This creates a variable "registered" with patient returning an integer of 1 if patient registered
-        at date. Patients who are not registered do not return a value:
+        This creates a variable "registered" with patient returning an integer of `1` if patient registered
+        at date. Patients who are not registered return an integer of `0`:
 
             registered=patients.registered_as_of(
                 "2020-03-01",
@@ -161,17 +165,25 @@ def registered_with_one_practice_between(
     All patients registered with the same practice through the given period
 
     Args:
-        start_date (str): date in format of YYYY-MM-DD
-        end_date (str): date in format of YYYY-MM-DD
-        return_expectations (dict, None): An expectation definition defining a rate
+        reference_date: .
+        return_expectations: a dictionary containing an expectation definition defining an `incidence`
+            between `0` and `1`.
+
+    Args:
+        start_date: start date of interest of period as a string with the format `YYYY-MM-DD`.
+            Together with end date, this filters results to patients registered at a practice between two dates
+        end_date: end date of interest of period as a string with the format `YYYY-MM-DD`.
+            Together with start date, this filters results to patients registered at a practice between two dates
+        return_expectations: a dictionary containing an expectation definition defining an `incidence`
+            between `0` and `1`.
 
     Returns:
-        list: Ones (as ints)
+        list: of integers of `1` or `0`.
 
     Example:
 
-        This creates a variable "registered_one" with patient returning an integer of 1 if patient registered
-        at one practice between two dates. Patients who are not registered do not return a value:
+        This creates a variable `registered_one` with patient returning an integer of `1` if patient registered
+        at one practice between two dates. Patients who are not registered return an integer of `0`.
 
             registered_one=patients.registered_with_one_practice_between(
                 start_date="2020-03-01",
@@ -193,18 +205,23 @@ def with_complete_history_between(
     dates
 
     Args:
-        start_date (str): date in format of YYYY-MM-DD
-        end_date (str): date in format of YYYY-MM-DD
-        return_expectations (dict, None): An expectation definition defining a rate
+        start_date: start date of interest of period as a string with the format `YYYY-MM-DD`.
+            Together with end date, this filters results to patients registered at a practice between two dates
+            who have a complete history.
+        end_date: end date of interest of period as a string with the format `YYYY-MM-DD`.
+            Together with start date, this filters results to patients registered at a practice between two dates
+            who have a complete history.
+        return_expectations: a dictionary containing an expectation definition defining an `incidence`
+            between `0` and `1`.
 
     Returns:
-        list: Ones (as ints)
+        list: of integers of `1` or `0`
 
     Example:
 
-        This creates a variable "has_consultation_history" with patient returning an integer of 1 if
-        patient registered at one practice between two dates and has a completed record. Patients who
-        are not registered do not return a value:
+        This creates a variable `has_consultation_history` with patient returning an integer of `1` if
+        patient registered at one practice between two dates and has a completed record. Patients who are
+        not registered  with a complete record return an integer of `0`.
 
         has_consultation_history=patients.with_complete_gp_consultation_history_between(
             start_date="2019-02-01",
@@ -243,33 +260,34 @@ def most_recent_bmi(
     weight measurement for this.
 
     Args:
-        on_or_before: Date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
-            on or before the given date.The default value is None.
-        on_or_after: Date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
-            on or after the given date.The default value is None.
-        between: Two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
-            Filters results to measurements between the two dates provided. The default value is None.
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or before the given date.The default value is `None`.
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or after the given date.The default value is `None`.
+        between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to measurements between the two dates provided. The default value is `None`.
         minimum_age_at_measurement: Measurements taken before this age will not count towards BMI
             calculations. It is an integer and the default value is 16.
-        return_expectations: This is a dictionary defining the incidence and distribution of expected BMI
+        return_expectations: a dictionary defining the incidence and distribution of expected BMI
             within the population in question. This is a 3-item key-value dictionary of "date" and "float".
-            "date" is dictionary itself and should contain the "earliest" and "latest" dates needed in the
-            dummy data. "float" is a dictionary of "distribution", "mean", and "stddev". These values determine
+            "date" is dictionary itself and should contain the `earliest` and `latest` dates needed in the
+            dummy data. `float` is a dictionary of `distribution`, `mean`, and `stddev`. These values determine
             the shape of the dummy data returned, and the float means a float will be returned rather than an
-            integer. "incidence" must have a value and this is what percentage of dummy patients have
+            integer. `incidence` must have a value and this is what percentage of dummy patients have
             a BMI. It needs to be a number between 0 and 1.
-        include_measurement_date: A boolean indicating if an extra column, named date_of_bmi,
-            should be included in the output. The default value is False.
-        date_format: This is a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
+        include_measurement_date: a boolean indicating if an extra column, named `date_of_bmi`,
+            should be included in the output. The default value is `False`.
+        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
             "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
             only year is less disclosive than a date with day, month and year. Only used if
-            include_measurement_date is True
+            include_measurement_date is `True`
         include_month: a boolean indicating if day should be included in addition to year (deprecated: use
             `date_format` instead).
         include_day: a boolean indicating if day should be included in addition to year and
             month (deprecated: use `date_format` instead).
+
     Returns:
-        float: Most recent BMI
+        float: most recent BMI
 
 
     Example:
@@ -282,7 +300,7 @@ def most_recent_bmi(
             between=["2010-02-01", "2020-01-31"],
             minimum_age_at_measurement=18,
             include_measurement_date=True,
-            include_month=True,
+            date_format="YYYY-MM",
             return_expectations={
                 "date": {"earliest": "2010-02-01", "latest": "2020-01-31"},
                 "float": {"distribution": "normal", "mean": 28, "stddev": 8},
@@ -317,24 +335,38 @@ def mean_recorded_value(
     The date of the measurement can be included by flagging with date format options.
 
     Args:
-        codelist (obj: Codelist): Codelist for requested value
-        on_most_recent_day_of_measurement (bool): flag for requesting measurements be on most recent date
-        return_expectations (dict, None): An expectation definition defining an incidence
-            and a distribution as a dict,
-        on_or_before (str, None): String of Data in YYYY-MM-DD format or None,
-        on_or_after (str, None): String of Data in YYYY-MM-DD format or None,
-        between (list, None): List of two date strings as YYYY-MM-DD format or None,
-        include_measurement_date (bool): Flag to return an additional column of date of bmi. Set as default to False
-        date_format (str): Date String of format to return date of measurement if flagged
-        include_month (bool): Flag for how granular to return date. Deprecated.
-        include_day (bool): Flag for how granular to return date. Deprecated.
+        codelist: a codelist for requested value
+        on_most_recent_day_of_measurement: boolean flag for requesting measurements be on most recent date
+        return_expectations: a dictionary defining the incidence and distribution of expected value
+            within the population in question. This is a 3-item key-value dictionary of "date" and "float".
+            "date" is dictionary itself and should contain the `earliest` and `latest` dates needed in the
+            dummy data. `float` is a dictionary of `distribution`, `mean`, and `stddev`. These values determine
+            the shape of the dummy data returned, and the float means a float will be returned rather than an
+            integer. `incidence` must have a value and this is what percentage of dummy patients have
+            a value. It needs to be a number between 0 and 1.
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or before the given date.The default value is `None`.
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or after the given date.The default value is `None`.
+        between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to measurements between the two dates provided. The default value is `None`.
+        include_measurement_date: a boolean indicating if an extra column, named `date_of_bmi`,
+            should be included in the output. The default value is `False`.
+        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
+            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+            only year is less disclosive than a date with day, month and year. Only used if
+            include_measurement_date is `True`
+        include_month: a boolean indicating if day should be included in addition to year (deprecated: use
+            `date_format` instead).
+        include_day: a boolean indicating if day should be included in addition to year and
+            month (deprecated: use `date_format` instead).
 
     Returns:
-        float: Mean of value
+        float: mean of value
 
     Example:
 
-        This creates a variable "bp_sys" returning a float of the most recent systolic blood pressure from
+        This creates a variable `bp_sys` returning a float of the most recent systolic blood pressure from
         the record within the time period. In the event of repeated measurements on the same day, these
         are averaged. Patient who do not have this information
         available do not return a value:
@@ -387,6 +419,72 @@ def with_these_medications(
     """
     Patients who have been prescribed at least one of this list of medications
     in the defined period
+
+    Args:
+        codelist: a codelist for requested medication(s)
+        return_expectations: a dictionary defining the incidence and distribution of expected value
+            within the population in question. If returning an integer (returning number_of_matches_in_period,
+            number_of_episodes), this is a 2-item key-value dictionary of `int` and `incidence`.
+            `int` is a dictionary of `distribution`, `mean`, and `stddev`. These values determine
+            the shape of the dummy data returned, and the int means a int will be returned rather than a
+            float. `incidence` must have a value and this is what percentage of dummy patients have
+            a value. It needs to be a number between 0 and 1. If returning `binary_flag` this is a 1-item
+            dictionary of `incidence` as described above. If returning either `first_date_in_period` or
+            `last_date_in_period`, this is a 2-item dictionary of `date` and `incidence`. `date` is a dict
+            of `earliest` and/or `latest` date possible.
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to on or
+            before the given date.The default value is `None`.
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
+            on or after the given date.The default value is `None`.
+        between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to between the two dates provided. The default value is `None`.
+        returning: a str defining the type of data to be returned. options include `binary_flag`,
+            `number_of_matches_in_period`, `number_of_episodes`, `first_date_in_period` and
+            `last_date_in_period`. The default value is `binary_flag`.
+        include_date_of_match: a boolean indicating if an extra column, should be included in the output.
+            The default value is `False`.
+        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
+            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+            only year is less disclosive than a date with day, month and year. Only used if include_date_of_match
+            is `True`
+        ignore_days_where_these_clinical_codes_occur: a codelist that contains codes for medications to be
+            ignored. if a medication is found on this day, the date is not matched even it matches a
+            code in the main `codelist`
+        episode_defined_as: a string expression indicating how an episode should be defined
+        return_binary_flag=None,
+        return_number_of_matches_in_period: a boolean indicating if the number of matches in a period should be
+            returned (deprecated: use `date_format` instead)
+        return_first_date_in_period: a boolean indicating if the first matches in a period should be
+            returned (deprecated: use `date_format` instead)
+        return_last_date_in_period: a boolean indicating if the last matches in a period should be
+            returned (deprecated: use `date_format` instead)
+        include_month: a boolean indicating if day should be included in addition to year (deprecated: use
+            `date_format` instead).
+        include_day: a boolean indicating if day should be included in addition to year and
+            month (deprecated: use `date_format` instead).
+
+    Returns:
+        list: of integers of `1` or `0` if `returning` argument is set to `binary_flag`, `number_of_episodes`
+            or `number_of_matches_in_period`; list of strings with a date format returned if `returning`
+            argument is set to `first_date_in_period` or `last_date_in_period`.
+
+    Example:
+
+        This creates a variable `exacerbation_count` returning an int of the number of episodes of oral
+        steroids being prescribed within the time period where a prescription is counted as part of the same
+        episode if it falls within 28 days of a previous prescription. Days where oral steroids
+        are prescribed on the same day as a COPD review are also ignored as may not represent true exacerbations.
+
+        exacerbation_count=patients.with_these_medications(
+            oral_steroid_med_codes,
+            between=["2019-03-01", "2020-02-29"],
+            ignore_days_where_these_clinical_codes_occur=copd_reviews,
+            returning="number_of_episodes",
+            episode_defined_as="series of events each <= 28 days apart",
+            return_expectations={
+                "int": {"distribution": "normal", "mean": 2, "stddev": 1},
+                "incidence": 0.2,
+            },
     """
     return "with_these_medications", locals()
 
@@ -422,6 +520,66 @@ def with_these_clinical_events(
     """
     Patients who have had at least one of these clinical events in the defined
     period
+
+    Args:
+        codelist: a codelist for requested event(s)
+        return_expectations: a dictionary defining the incidence and distribution of expected value
+            within the population in question. If returning an integer (returning number_of_matches_in_period,
+            number_of_episodes), this is a 2-item key-value dictionary of `int` and `incidence`.
+            `int` is a dictionary of `distribution`, `mean`, and `stddev`. These values determine
+            the shape of the dummy data returned, and the int means a int will be returned rather than a
+            float. `incidence` must have a value and this is what percentage of dummy patients have
+            a value. It needs to be a number between 0 and 1. If returning `binary_flag` this is a 1-item
+            dictionary of `incidence` as described above. If returning either `first_date_in_period` or
+            `last_date_in_period`, this is a 2-item dictionary of `date` and `incidence`. `date` is a dict
+            of `earliest` and/or `latest` date possible.
+        on_or_before: date of interest as a string with the format `YYYY-MM-DD`. Filters results to on or
+            before the given date.The default value is `None`.
+        on_or_after: date of interest as a string with the format `YYYY-MM-DD`. Filters results to
+            on or after the given date.The default value is `None`.
+        between: two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to between the two dates provided. The default value is `None`.
+        returning: a str defining the type of data to be returned. options include `binary_flag`,
+            `number_of_matches_in_period`, `number_of_episodes`, `first_date_in_period` and
+            `last_date_in_period`. The default value is `binary_flag`.
+        include_date_of_match: a boolean indicating if an extra column, should be included in the output.
+            The default value is `False`.
+        date_format: a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
+            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+            only year is less disclosive than a date with day, month and year. Only used if include_date_of_match
+            is `True`
+        ignore_days_where_these_codes_occur: a codelist that contains codes for events to be
+            ignored. if a events is found on this day, the date is not matched even it matches a
+            code in the main `codelist`
+        episode_defined_as: a string expression indicating how an episode should be defined
+        return_binary_flag=None,
+        return_number_of_matches_in_period: a boolean indicating if the number of matches in a period should be
+            returned (deprecated: use `date_format` instead)
+        return_first_date_in_period: a boolean indicating if the first matches in a period should be
+            returned (deprecated: use `date_format` instead)
+        return_last_date_in_period: a boolean indicating if the last matches in a period should be
+            returned (deprecated: use `date_format` instead)
+        include_month: a boolean indicating if day should be included in addition to year (deprecated: use
+            `date_format` instead).
+        include_day: a boolean indicating if day should be included in addition to year and
+            month (deprecated: use `date_format` instead).
+
+    Returns:
+        list: of integers of `1` or `0` if `returning` argument is set to `binary_flag`, `number_of_episodes`
+            or `number_of_matches_in_period`; list of strings with a date format returned if `returning`
+            argument is set to `first_date_in_period` or `last_date_in_period`.
+
+    Example:
+
+        This creates a variable `haem_cancer` returning the first date of a diagnosis of haematology
+         malignancy within the time period.
+
+        haem_cancer=patients.with_these_clinical_events(
+            haem_cancer_codes,
+            between=["2015-03-01", "2020-02-29"],
+            returning="first_date_in_period",
+            return_expectations={"date": {"latest": "2020-02-29"}
+            },
     """
     return "with_these_clinical_events", locals()
 

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1,12 +1,12 @@
+""" This module provides the methods for making a study definition """
 # These methods don't *do* anything; they just return their name and arguments.
-# This provides a friendlier API then having to build some big nested data
+# This provides a friendlier API than having to build some big nested data
 # structure by hand and means we can make use of autocomplete, docstrings etc to
 # make it a bit more discoverable.
 
-
-
 # Yes this clashes with the builtin, but we don't need the builtin in this
 # context
+
 def all():
     return "all", locals()
 
@@ -60,7 +60,7 @@ def age_as_of(
     return_expectations=None,
 ):
     """
-    Returns age of patient of at a particular date
+    Returns age of patient of at a particular date. Note can be negative if born after `reference_date`.
 
     Args:
         reference_date: date of interest as a string with the format `YYYY-MM-DD`

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1,9 +1,8 @@
-"""
-These methods don't *do* anything; they just return their name and arguments.
-This provides a friendlier API then having to build some big nested data
-structure by hand and means we can make use of autocomplete, docstrings etc to
-make it a bit more discoverable.
-"""
+# These methods don't *do* anything; they just return their name and arguments.
+# This provides a friendlier API then having to build some big nested data
+# structure by hand and means we can make use of autocomplete, docstrings etc to
+# make it a bit more discoverable.
+
 
 
 # Yes this clashes with the builtin, but we don't need the builtin in this
@@ -14,7 +13,20 @@ def all():
 
 def random_sample(percent=None, return_expectations=None):
     """
-    A random sample of approximately `percent` patients
+    Flags a random sample of approximately `percent` patients.
+
+    Args:
+        percent (int): Number between 1 and 100
+        return_expectations (dict): an expectations definition defining at least an `incidence`
+
+    Returns:
+        list: zeros and ones
+
+    Example:
+        This creates a variable `training_set`, flagging approximately 10% of the population with the value `1`:
+
+            training_set=patients.random_sample(percent=10, expectations={'incidence': 0.1})
+
     """
     return "random_sample", locals()
 
@@ -22,6 +34,7 @@ def random_sample(percent=None, return_expectations=None):
 def sex(return_expectations=None):
     """
     Returns M, F or empty string if unknown or other
+
     """
     return "sex", locals()
 
@@ -667,19 +680,37 @@ def admitted_to_hospital(
     with_these_procedures=None,
     return_expectations=None,
 ):
-    """Return information about admission to hospital.
+    """"
+    Return information about admission to hospital.
 
-    Options for `returning` are:
+    See https://github.com/opensafely/cohort-extractor/issues/186 for in-depth discussion and background.
 
-        binary_flag: Whether patient was admitted to hospital
-        primary_diagnosis: ICD-10 code of primary diagnosis
-        date_admitted: Date patient was admitted to hospital
-        date_discharged: Date patient was discharged from hospital
+    Args:
+        on_or_before (str): The latest date of admission
+        on_or_after (str): The earliest date of admission
+        between (list): A tuple of [`on_or_after`, `on_or_before`]
+        returning (str): One of `binary_flag` (if they were admitted at all), `date_admitted`, `date_discharged`, `number_of_matches_in_period`, `primary_diagnosis`
+        find_first_match_in_period (bool): For date return values, always choose the earliest matching occurence
+        find_last_match_in_period (bool): For date return values, always choose the latest matching occurence
+        date_format (str): A date format string of the form `YYYY`, `YYYY-MM` or `YYYY-MM-DD`
+        with_these_diagnoses (codelist): icd10 codes to match against any diagnosis
+        with_these_primary_diagnoses (codelist): icd10 codes to match against the primary diagnosis
+        with_these_procedures (codelist): OPCS-4 codes to match against the procedure
 
-    `with_these_diagnoses` is optional, and is a list of ICD-10 codes
-    `with_these_primary_diagnoses` is optional, and is a list of ICD-10 codes
-    `with_these_procedures` is optional, and is a list of OPCS-4 codes
+    Returns:
+        list: strings corresponding to the requested `returning` value
 
-    See https://github.com/opensafely/cohort-extractor/issues/186 for discussion.
+    Example:
+        The day of each patient's first hospital admission for Covid19:
+
+            covid_admission_date=patients.admitted_to_hospital(
+                returning= "date_admitted",
+                with_these_diagnoses=covid_codelist,
+                on_or_after="2020-02-01",
+                find_first_match_in_period=True,
+                date_format="YYYY-MM-DD",
+                return_expectations={"date": {"earliest": "2020-03-01"}},
+            )
     """
+
     return "admitted_to_hospital", locals()

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -243,14 +243,14 @@ def most_recent_bmi(
     weight measurement for this.
 
     Args:
-        on_or_before: Date of interest as a string with the format "YYYY-MM-DD". This will find data
-            on or before the date of interest. The default value is None.
-        on_or_after: Date of interest as a string with the format "YYYY-MM-DD". This will find data
-            on or after the date of interest. The default value is None.
-        between: Two dates of interest as a list with each date as a string with the format "YYYY-MM-DD".
-            This will find data between the two dates only. The default value in None.
-        minimum_age_at_measurement: This is the minimum age at measurement of BMI. It is an integer
-            and the default value is 16.
+        on_or_before: Date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or before the given date.The default value is None.
+        on_or_after: Date of interest as a string with the format `YYYY-MM-DD`. Filters results to measurements
+            on or after the given date.The default value is None.
+        between: Two dates of interest as a list with each date as a string with the format `YYYY-MM-DD`.
+            Filters results to measurements between the two dates provided. The default value is None.
+        minimum_age_at_measurement: Measurements taken before this age will not count towards BMI
+            calculations. It is an integer and the default value is 16.
         return_expectations: This is a dictionary defining the incidence and distribution of expected BMI
             within the population in question. This is a 3-item key-value dictionary of "date" and "float".
             "date" is dictionary itself and should contain the "earliest" and "latest" dates needed in the
@@ -258,18 +258,16 @@ def most_recent_bmi(
             the shape of the dummy data returned, and the float means a float will be returned rather than an
             integer. "incidence" must have a value and this is what percentage of dummy patients have
             a BMI. It needs to be a number between 0 and 1.
-        include_measurement_date: This is a boolean flag (i.e. True or False) which if True allows us to
-            return an additional column of date of bmi. The default value is False.
+        include_measurement_date: A boolean indicating if an extra column, named date_of_bmi,
+            should be included in the output. The default value is False.
         date_format: This is a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
             "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
-            only year is less disclosive than a date with day, month and year. The "include_measurement_date" flag
-            needs to be True for this to return a date.
-        include_month: This is a boolean flag for how granular to return date. In this case to return month as
-            well as year.. This is a deprecated argument, which is still supported for old versions and has been
-            replaced by the "date_format" argument.
-        include_day: This is a boolean flag for how granular to return date. In this case to return day as
-            well as year and month. This is a deprecated argument, which is still supported for old versions and
-            has been replaced by the "date_format" argument.
+            only year is less disclosive than a date with day, month and year. Only used if
+            include_measurement_date is True
+        include_month: a boolean indicating if day should be included in addition to year (deprecated: use
+            `date_format` instead).
+        include_day: a boolean indicating if day should be included in addition to year and
+            month (deprecated: use `date_format` instead).
     Returns:
         float: Most recent BMI
 

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -71,7 +71,7 @@ def age_as_of(
     Returns:
         list: Ages as integers
 
-    Examples:
+    Example:
         This creates a variable "age" with all patient returning an age as an integer:
 
             age=patients.age_as_of(
@@ -104,10 +104,13 @@ def date_of_birth(
         ValueError: If Date of Birth is attempted to be returned with a YYYY-MM-DD format.
 
     Example:
-        dob=patients.date_of_birth(
-            "YYYY-MM",
-            return_expectations={ TODO: find out about this!!
-                }
+
+        This creates a variable "dob" with all patient returning a year and month as a string:
+
+            dob=patients.date_of_birth(
+                "YYYY-MM",
+                return_expectations={ TODO: find out about this!!
+                    }
     """
 
     # The actual enforcement of this information governance rule is done in the
@@ -135,10 +138,14 @@ def registered_as_of(
         list: Ones (as ints)
 
     Example:
-        registered=patients.registered_as_of(
-            "2020-03-01",
-            return_expectations={"incidence": 0.98}
-            )
+
+        This creates a variable "registered" with patient returning an integer of 1 if patient registered
+        at date. Patients who are not registered do not return a value:
+
+            registered=patients.registered_as_of(
+                "2020-03-01",
+                return_expectations={"incidence": 0.98}
+                )
 
     """
     return "registered_as_of", locals()
@@ -162,11 +169,15 @@ def registered_with_one_practice_between(
         list: Ones (as ints)
 
     Example:
-        registered=patients.registered_with_one_practice_between(
-            start_date="2020-03-01",
-            end_date="2020-06-01",
-            return_expectations={"incidence": 0.90}
-            )
+
+        This creates a variable "registered_one" with patient returning an integer of 1 if patient registered
+        at one practice between two dates. Patients who are not registered do not return a value:
+
+            registered_one=patients.registered_with_one_practice_between(
+                start_date="2020-03-01",
+                end_date="2020-06-01",
+                return_expectations={"incidence": 0.90}
+                )
     """
     return "registered_with_one_practice_between", locals()
 
@@ -190,6 +201,11 @@ def with_complete_history_between(
         list: Ones (as ints)
 
     Example:
+
+        This creates a variable "has_consultation_history" with patient returning an integer of 1 if
+        patient registered at one practice between two dates and has a completed record. Patients who
+        are not registered do not return a value:
+
         has_consultation_history=patients.with_complete_gp_consultation_history_between(
             start_date="2019-02-01",
             end_date="2020-01-31",
@@ -243,16 +259,21 @@ def most_recent_bmi(
 
 
     Example:
-        bmi=patients.most_recent_bmi(
-        between=["2010-02-01", "2020-01-31"],
-        minimum_age_at_measurement=18,
-        include_measurement_date=True,
-        include_month=True,
-        return_expectations={
-            "date": {"earliest": "2010-02-01", "latest": "2020-01-31"},
-            "float": {"distribution": "normal", "mean": 28, "stddev": 8},
-            "incidence": 0.95,
-        }
+
+        This creates a variable "bmi" returning a float of the most recent bmi calculated from recorded
+        height and weight, or from a recorded bmi record. Patient who do not have this information
+        available do not return a value:
+
+            bmi=patients.most_recent_bmi(
+            between=["2010-02-01", "2020-01-31"],
+            minimum_age_at_measurement=18,
+            include_measurement_date=True,
+            include_month=True,
+            return_expectations={
+                "date": {"earliest": "2010-02-01", "latest": "2020-01-31"},
+                "float": {"distribution": "normal", "mean": 28, "stddev": 8},
+                "incidence": 0.80,
+            }
 
     """
     return "most_recent_bmi", locals()
@@ -298,18 +319,24 @@ def mean_recorded_value(
         float: Mean of value
 
     Example:
-        bp_sys=patients.mean_recorded_value(
-        systolic_blood_pressure_codes,
-        on_most_recent_day_of_measurement=True,
-        between=["2017-02-01", "2020-01-31"],
-        include_measurement_date=True,
-        include_month=True,
-        return_expectations={
-            "float": {"distribution": "normal", "mean": 80, "stddev": 10},
-            "date": {"earliest": "2019-02-01", "latest": "2020-01-31"},
-            "incidence": 0.95,
-        },
-    ),
+
+        This creates a variable "bp_sys" returning a float of the most recent systolic blood pressure from
+        the record within the time period. In the event of repeated measurements on the same day, these
+        are averaged. Patient who do not have this information
+        available do not return a value:
+
+            bp_sys=patients.mean_recorded_value(
+            systolic_blood_pressure_codes,
+            on_most_recent_day_of_measurement=True,
+            between=["2017-02-01", "2020-01-31"],
+            include_measurement_date=True,
+            date_format="YYYY-MM",
+            return_expectations={
+                "float": {"distribution": "normal", "mean": 80, "stddev": 10},
+                "date": {"earliest": "2019-02-01", "latest": "2020-01-31"},
+                "incidence": 0.95,
+            },
+        ),
     """
 
     return "mean_recorded_value", locals()

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -16,8 +16,8 @@ def random_sample(percent=None, return_expectations=None):
     Flags a random sample of approximately `percent` patients.
 
     Args:
-        percent (int): Number between 1 and 100
-        return_expectations (dict): an expectations definition defining at least an `incidence`
+        percent: Number between 1 and 100
+        return_expectations: an expectations definition defining at least an `incidence`
 
     Returns:
         list: zeros and ones
@@ -243,17 +243,33 @@ def most_recent_bmi(
     weight measurement for this.
 
     Args:
-        on_or_before (str, None): String of Data in YYYY-MM-DD format or None,
-        on_or_after (str, None): String of Data in YYYY-MM-DD format or None,
-        between (list, None): List of two date strings as YYYY-MM-DD format or None,
-        minimum_age_at_measurement (int): Minimum age at measurement. Default value is 16.
-        return_expectations (dict, None): An expectation definition defining an incidence
-            and a distribution as a dict,
-        include_measurement_date (bool): Flag to return an additional column of date of bmi. Set as default to False
-        date_format (str): Date String of format to return date of measurement if flagged
-        include_month (bool): Flag for how granular to return date
-        include_day (bool): Flag for how granular to return date
-
+        on_or_before: Date of interest as a string with the format "YYYY-MM-DD". This will find data
+            on or before the date of interest. The default value is None.
+        on_or_after: Date of interest as a string with the format "YYYY-MM-DD". This will find data
+            on or after the date of interest. The default value is None.
+        between: Two dates of interest as a list with each date as a string with the format "YYYY-MM-DD".
+            This will find data between the two dates only. The default value in None.
+        minimum_age_at_measurement: This is the minimum age at measurement of BMI. It is an integer
+            and the default value is 16.
+        return_expectations: This is a dictionary defining the incidence and distribution of expected BMI
+            within the population in question. This is a 3-item key-value dictionary of "date" and "float".
+            "date" is dictionary itself and should contain the "earliest" and "latest" dates needed in the
+            dummy data. "float" is a dictionary of "distribution", "mean", and "stddev". These values determine
+            the shape of the dummy data returned, and the float means a float will be returned rather than an
+            integer. "incidence" must have a value and this is what percentage of dummy patients have
+            a BMI. It needs to be a number between 0 and 1.
+        include_measurement_date: This is a boolean flag (i.e. True or False) which if True allows us to
+            return an additional column of date of bmi. The default value is False.
+        date_format: This is a string detailing the format of the dates to be returned. It can be "YYYY-MM-DD",
+            "YYYY-MM" or "YYYY" and wherever possible the least disclosive data should be returned. i.e returning
+            only year is less disclosive than a date with day, month and year. The "include_measurement_date" flag
+            needs to be True for this to return a date.
+        include_month: This is a boolean flag for how granular to return date. In this case to return month as
+            well as year.. This is a deprecated argument, which is still supported for old versions and has been
+            replaced by the "date_format" argument.
+        include_day: This is a boolean flag for how granular to return date. In this case to return day as
+            well as year and month. This is a deprecated argument, which is still supported for old versions and
+            has been replaced by the "date_format" argument.
     Returns:
         float: Most recent BMI
 

--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -124,14 +124,21 @@ def registered_as_of(
     return_expectations=None,
 ):
     """
-    All patients registered on the given date. This functions passes arguments
+    All patients registered on the given date. Note this function passes arguments
     to registered_with_one_practice_between()
 
     Args:
         reference_date (str): date in format of YYYY-MM-DD
+        return_expectations (dict, None): An expectation definition defining a rate
 
     Returns:
         list: Ones (as ints)
+
+    Example:
+        registered=patients.registered_as_of(
+            "2020-03-01",
+            return_expectations={"incidence": 0.98}
+            )
 
     """
     return "registered_as_of", locals()
@@ -145,6 +152,21 @@ def registered_with_one_practice_between(
 ):
     """
     All patients registered with the same practice through the given period
+
+    Args:
+        start_date (str): date in format of YYYY-MM-DD
+        end_date (str): date in format of YYYY-MM-DD
+        return_expectations (dict, None): An expectation definition defining a rate
+
+    Returns:
+        list: Ones (as ints)
+
+    Example:
+        registered=patients.registered_with_one_practice_between(
+            start_date="2020-03-01",
+            end_date="2020-06-01",
+            return_expectations={"incidence": 0.90}
+            )
     """
     return "registered_with_one_practice_between", locals()
 
@@ -158,6 +180,21 @@ def with_complete_history_between(
     """
     All patients for which we have a full set of records between the given
     dates
+
+    Args:
+        start_date (str): date in format of YYYY-MM-DD
+        end_date (str): date in format of YYYY-MM-DD
+        return_expectations (dict, None): An expectation definition defining a rate
+
+    Returns:
+        list: Ones (as ints)
+
+    Example:
+        has_consultation_history=patients.with_complete_gp_consultation_history_between(
+            start_date="2019-02-01",
+            end_date="2020-01-31",
+            return_expectations={"incidence": 0.9},
+        )
     """
     return "with_complete_history_between", locals()
 
@@ -188,6 +225,35 @@ def most_recent_bmi(
     The date of the measurement can be obtained using `date_of("<bmi-column-name>")`.
     If the BMI is computed from weight and height then we use the date of the
     weight measurement for this.
+
+    Args:
+        on_or_before (str, None): String of Data in YYYY-MM-DD format or None,
+        on_or_after (str, None): String of Data in YYYY-MM-DD format or None,
+        between (list, None): List of two date strings as YYYY-MM-DD format or None,
+        minimum_age_at_measurement (int): Minimum age at measurement. Default value is 16.
+        return_expectations (dict, None): An expectation definition defining an incidence
+            and a distribution as a dict,
+        include_measurement_date (bool): Flag to return an additional column of date of bmi. Set as default to False
+        date_format (str): Date String of format to return date of measurement if flagged
+        include_month (bool): Flag for how granular to return date
+        include_day (bool): Flag for how granular to return date
+
+    Returns:
+        float: Most recent BMI
+
+
+    Example:
+        bmi=patients.most_recent_bmi(
+        between=["2010-02-01", "2020-01-31"],
+        minimum_age_at_measurement=18,
+        include_measurement_date=True,
+        include_month=True,
+        return_expectations={
+            "date": {"earliest": "2010-02-01", "latest": "2020-01-31"},
+            "float": {"distribution": "normal", "mean": 28, "stddev": 8},
+            "incidence": 0.95,
+        }
+
     """
     return "most_recent_bmi", locals()
 
@@ -208,6 +274,44 @@ def mean_recorded_value(
     include_month=False,
     include_day=False,
 ):
+    """
+    Return patients' mean recorded value of a numerical value as defined by
+    a codelist on a particular day within the defined period. This is important as allows
+    us to account for multiple measurements taken on one day.
+
+    The date of the measurement can be included by flagging with date format options.
+
+    Args:
+        codelist (obj: Codelist): Codelist for requested value
+        on_most_recent_day_of_measurement (bool): flag for requesting measurements be on most recent date
+        return_expectations (dict, None): An expectation definition defining an incidence
+            and a distribution as a dict,
+        on_or_before (str, None): String of Data in YYYY-MM-DD format or None,
+        on_or_after (str, None): String of Data in YYYY-MM-DD format or None,
+        between (list, None): List of two date strings as YYYY-MM-DD format or None,
+        include_measurement_date (bool): Flag to return an additional column of date of bmi. Set as default to False
+        date_format (str): Date String of format to return date of measurement if flagged
+        include_month (bool): Flag for how granular to return date. Deprecated.
+        include_day (bool): Flag for how granular to return date. Deprecated.
+
+    Returns:
+        float: Mean of value
+
+    Example:
+        bp_sys=patients.mean_recorded_value(
+        systolic_blood_pressure_codes,
+        on_most_recent_day_of_measurement=True,
+        between=["2017-02-01", "2020-01-31"],
+        include_measurement_date=True,
+        include_month=True,
+        return_expectations={
+            "float": {"distribution": "normal", "mean": 80, "stddev": 10},
+            "date": {"earliest": "2019-02-01", "latest": "2020-01-31"},
+            "incidence": 0.95,
+        },
+    ),
+    """
+
     return "mean_recorded_value", locals()
 
 


### PR DESCRIPTION
Following some iteration, these should eventually make it to
our documentation, automatically.

The main point of discussion is if there's benefit to moving to a more typed API sooner rather than later. For example, enums for `date_format`, custom types for `return_expectations`, etc.

On the one hand, this will tighten up our contracts and improve the documentation.

On the other hand, tightening up our contracts will force a major rationalisation / refactor which we know is coming but maybe isn't a top priority.

Here's how it renders in `mkdocstring`:

![image](https://user-images.githubusercontent.com/211271/96607543-5e641380-12f0-11eb-90de-ee1c4192d613.png)



