### PR TITLE
fix: Quick fix for inconsistent ONS death data

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1152,6 +1152,17 @@ class TPPBackend:
             column_definition = "1"
         elif returning == "date_of_death":
             column_definition = "dod"
+            # Quick fix: a patient appears twice in the ONS data with different
+            # dates of death (offset by one day). This results in an error when
+            # running the extract.  As we need to extract this cohort urgently
+            # we're going to use the minimum date for now, pending a full
+            # discussion of how best to handle this kind of inconsistency.
+            return f"""
+            SELECT Patient_ID as patient_id, MIN(dod) AS {returning}
+            FROM ONS_Deaths
+            WHERE ({code_conditions}) AND {date_condition}
+            GROUP BY patient_id
+            """
         elif returning == "underlying_cause_of_death":
             column_definition = "icd10u"
         else:

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1300,6 +1300,10 @@ def test_patients_with_these_codes_on_death_certificate():
             ONSDeaths(
                 Patient=patient_with_dupe, dod="2020-02-01", icd10u=code, ICD10014="MI"
             ),
+            # A duplicate with a different date of death (which now we have to handle)
+            ONSDeaths(
+                Patient=patient_with_dupe, dod="2020-02-02", icd10u=code, ICD10014="MI"
+            ),
             # Covid not underlying cause
             ONSDeaths(Patient=Patient(), dod="2020-03-01", icd10u="MI", ICD10014=code),
         ]


### PR DESCRIPTION
A patient appears twice in the ONS data with different dates of death
(offset by one day). This results in an error when running the extract.
As we need to extract this cohort urgently we're going to use the
minimum date for now, pending a full discussion of how best to handle
this kind of inconsistency.