### PR TITLE
feat: Allow empty string literals in expressions

### DIFF
--- a/cohortextractor/expressions.py
+++ b/cohortextractor/expressions.py
@@ -95,7 +95,7 @@ def validate_string(token):
     value = token.value[1:-1]
     if len(value) > 16:
         raise ValueError(f"String literals must be 16 characters or less: {value}")
-    if not SAFE_CHARS_RE.match(value):
+    if not SAFE_CHARS_RE.match(value) and not value == "":
         raise ValueError(
             f"String literals can only contain alphanumeric characters and "
             f"underscore: {value}"

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -20,3 +20,15 @@ def test_validation():
         format_expression("(a AND b", **kwargs)
     with pytest.raises(InvalidExpressionError):
         format_expression("a > > b", **kwargs)
+
+
+def test_validate_string():
+    kwargs = dict(name_map={}, empty_value_map={})
+    with pytest.raises(ValueError):
+        format_expression('"no spaces"', **kwargs)
+    with pytest.raises(ValueError):
+        format_expression('"no$special$chars"', **kwargs)
+    with pytest.raises(ValueError):
+        format_expression('"all_ok_characters_but_just_a_bit_too_long"', **kwargs)
+    assert format_expression('"quoted"', **kwargs) == "'quoted'"
+    assert format_expression('""', **kwargs) == "''"


### PR DESCRIPTION
We sometimes have a legitimate need to compare values to the empty
string.