### PR TITLE
Bump jobrunner dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="tech@opensafely.org",
     python_requires=">=3.7",
     install_requires=[
-        "opensafely-jobrunner>=1.8.1",
+        "opensafely-jobrunner>=2.0,<3.0",
         "pandas",
         "prettytable",
         "pyyaml",


### PR DESCRIPTION
job-runner v2 has a shim file `jobrunner/job.py` which presents the same
API as the old job-runner and makes it a drop-in replacement.