### PR TITLE
feat: Support multiple columns in measure `group_by`

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -288,7 +288,7 @@ def _generate_measures(output_dir, study_name, suffix, skip_existing=False):
 def _calculate_measure_df(patient_df, measure):
     if measure.group_by:
         measure_df = patient_df[
-            [measure.numerator, measure.denominator, measure.group_by]
+            [measure.numerator, measure.denominator, *measure.group_by]
         ]
         measure_df = measure_df.groupby(measure.group_by).sum()
         measure_df = measure_df.reset_index()
@@ -314,8 +314,7 @@ def _load_csv_for_measures(file, measures):
     group_by_columns = set()
     for measure in measures:
         numeric_columns.update([measure.numerator, measure.denominator])
-        if measure.group_by:
-            group_by_columns.add(measure.group_by)
+        group_by_columns.update(measure.group_by)
     # This is a special column which we don't load from the CSV but whose value
     # is always set to 1 for every row
     numeric_columns.discard("population")

--- a/cohortextractor/measure.py
+++ b/cohortextractor/measure.py
@@ -3,4 +3,9 @@ class Measure:
         self.id = id
         self.denominator = denominator
         self.numerator = numerator
-        self.group_by = group_by
+        if group_by is None:
+            self.group_by = []
+        elif not isinstance(group_by, (list, tuple)):
+            self.group_by = [group_by]
+        else:
+            self.group_by = group_by

--- a/cohortextractor/measure.py
+++ b/cohortextractor/measure.py
@@ -1,5 +1,31 @@
 class Measure:
     def __init__(self, id, denominator, numerator, group_by=None):
+        """
+        Creates a "measure" using data extracted by the StudyDefinition defined
+        in the same file.
+
+        Args:
+            id: A string used for the output filename (which will be
+                `measure_<id>.csv`).  Only alphanumeric and underscore characters
+                allowed.
+            numerator: A column name from the study definition. This must be
+                numeric or boolean. For boolean columns the value of the numerator
+                will be the number of patients with the value "true".
+            denominator: A column name from the study definition, or the
+                special name "population". Columns must be numeric or boolean.
+                For boolean columns the value of the denominator will be the
+                number of patients with the value "true". Using the
+                "population" denominator will give you the total number of
+                patients in the cohort.
+            group_by: A column name, or a list of column names, from the study
+                definition to group results by. Use the special column
+                "population" to treat the entire population as a single group.
+                Set group_by to None (or omit it entirely) to perform no
+                grouping and leave the data at individual patient level.
+
+        Returns:
+            Measure instance
+        """
         self.id = id
         self.denominator = denominator
         self.numerator = numerator

--- a/tests/fixtures/smoketest/analysis/study_definition.py
+++ b/tests/fixtures/smoketest/analysis/study_definition.py
@@ -166,4 +166,10 @@ measures = [
         denominator="population",
         group_by="stp",
     ),
+    Measure(
+        id="liver_disease_by_stp_and_sex",
+        numerator="has_chronic_liver_disease",
+        denominator="population",
+        group_by=["stp", "sex"],
+    ),
 ]

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -25,6 +25,7 @@ def test_smoketest(tmp_path):
         "--output-dir",
         tmp_path,
     )
+    # liver_disease_by_stp
     with open(tmp_path / "measure_liver_disease_by_stp.csv") as f:
         contents = list(csv.reader(f))
     assert contents[0] == [
@@ -37,6 +38,21 @@ def test_smoketest(tmp_path):
     assert len(contents) == 1 + (2 * 4)  # Header row + 2 STPs * 4 dates
     dates = set(row[4] for row in contents[1:])
     assert dates == {"2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"}
+    # liver_disease_by_stp_and_sex
+    with open(tmp_path / "measure_liver_disease_by_stp_and_sex.csv") as f:
+        contents = list(csv.reader(f))
+    assert contents[0] == [
+        "stp",
+        "sex",
+        "has_chronic_liver_disease",
+        "population",
+        "value",
+        "date",
+    ]
+    assert len(contents) == 1 + (2 * 2 * 4)  # Header row + 2 STPs * 2 sexes * 4 dates
+    dates = set(row[5] for row in contents[1:])
+    assert dates == {"2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01"}
+    # liver_disease
     with open(tmp_path / "measure_liver_disease.csv") as f:
         contents = list(csv.reader(f))
     assert contents[0] == [


### PR DESCRIPTION
Just supply a list or tuple of `group_by` columns e.g
```py
measures = [
    Measure(
        id="liver_disease_by_stp_and_sex",
        numerator="has_chronic_liver_disease",
        denominator="population",
        group_by=["stp", "sex"],
    ),
]
```

Closes #355