### PR TITLE
Randomise dummy data patient_id

### DIFF
--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -3,6 +3,7 @@ import copy
 import os
 
 import pandas as pd
+from numpy.random import default_rng
 
 from .expectation_generators import generate
 from .process_covariate_definitions import process_covariate_definitions
@@ -70,8 +71,9 @@ class StudyDefinition:
             df = self.make_df_from_expectations(expectations_population)
             # Turn the index into a dummy patient_id column; longer
             # term, we don't plan to include this in the output
-            df = df.reset_index()
-            df = df.rename(columns={"index": "patient_id"})
+            df["patient_id"] = default_rng().choice(
+                (len(df) * 10), size=len(df), replace=False
+            )
             df.to_csv(filename, index=False)
         else:
             self.assert_backend_is_configured()

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -69,6 +69,8 @@ class StudyDefinition:
     def to_csv(self, filename, expectations_population=False, **kwargs):
         if expectations_population:
             df = self.make_df_from_expectations(expectations_population)
+            # Add a patient ID - a randomly generated integer from an
+            # array 10x larger than the cohort.
             df["patient_id"] = default_rng().choice(
                 (len(df) * 10), size=len(df), replace=False
             )

--- a/cohortextractor/study_definition.py
+++ b/cohortextractor/study_definition.py
@@ -69,8 +69,6 @@ class StudyDefinition:
     def to_csv(self, filename, expectations_population=False, **kwargs):
         if expectations_population:
             df = self.make_df_from_expectations(expectations_population)
-            # Turn the index into a dummy patient_id column; longer
-            # term, we don't plan to include this in the output
             df["patient_id"] = default_rng().choice(
                 (len(df) * 10), size=len(df), replace=False
             )


### PR DESCRIPTION
This way the `patient_id` is more representative of those in the real data, rather than a sequential list of integers. This fixes a specific issue with https://github.com/opensafely/matching, which drops the patients in one extract from another extract. Previously, the two extracts had identical `patient_id` in the dummy data, leading to all dummy patients being dropped, e.g. in [this error](https://github.com/opensafely/post-covid-thrombosis-research/runs/1524905879?check_suite_focus=true).

To consider: I can't remember if `patient_id` in the real data end up sorted, might be worth also sorting them here if so?

Also, re: the deleted comment, I'd argue that we always need the `patient_id` col in the output.