### PR TITLE
fix: only warn on duplicate rows in EMIS

### DIFF
--- a/cohortextractor/emis_backend.py
+++ b/cohortextractor/emis_backend.py
@@ -1207,7 +1207,9 @@ class UniqueCheck:
     def assert_unique_ids(self):
         duplicates = self.count - len(self.ids)
         if duplicates != 0:
-            raise RuntimeError(f"Duplicate IDs found ({duplicates} rows)")
+            print("-" * 80)
+            print(f"Duplicate IDs found ({duplicates} rows)")
+            print("-" * 80)
 
 
 def pop_keys_from_dict(dictionary, keys):

--- a/tests/test_emis_backend.py
+++ b/tests/test_emis_backend.py
@@ -1328,6 +1328,7 @@ def test_patients_with_death_recorded_in_cpns_raises_error_on_bad_data():
         study.to_dicts()
 
 
+@pytest.mark.xfail
 def test_duplicate_id_checking():
     study = StudyDefinition(population=patients.all())
     # A bit of a hack: overwrite the queries we're going to run with a query which


### PR DESCRIPTION
There are a handful of duplicate IDs in EMIS