### PR TITLE
feat: Support getting MSOA from patient address

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -693,12 +693,12 @@ def registered_practice_as_of(
 
     Args:
         date: date of interest as a string with the format `YYYY-MM-DD`. Filters results to the given date.
-        returning: a str defining the type of data to be returned. options include `msoa_code`, nuts1_region_name,
+        returning: a str defining the type of data to be returned. options include `msoa`, nuts1_region_name,
              and `stp_code`. The default value is `None`.
         return_expectations: a dict defining the `rate` and the `categories` returned with ratios
 
     Returns:
-        list: of integers representing a scale of `stp_code`, `msoa_code` or `nuts1_region_name`
+        list: of strings
 
     Raises:
         ValueError: if unsupported `returning` argument is provided
@@ -743,13 +743,13 @@ def address_as_of(
     Args:
         date: date of interest as a string with the format `YYYY-MM-DD`. Filters results to the given date.
         returning: a str defining the type of data to be returned. options include `index_of_multiple_deprivation`
-             and `rural_urban_classification`. The default value is `None`.
+            `rural_urban_classification`, and `msoa`. The default value is `None`.
         round_to_nearest: an integer that represents how `index_of_multiple_deprivation` value are rounded.
             Only use when returning is `index_of_multiple_deprivation`
         return_expectations: a dict defining the `rate` and the `categories` returned with ratios
 
     Returns:
-        list: of integers representing a scale of either imd or rural-urban classificaiton
+        list: of integers for `rural_urban_classification` and `index_of_multiple_deprivation`, strings for `msoa`
 
     Raises:
         ValueError: if unsupported `returning` argument is provided

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1139,7 +1139,9 @@ class TPPBackend:
     def patients_registered_practice_as_of(self, date, returning=None):
         if returning == "stp_code":
             column = "STPCode"
-        elif returning == "msoa_code":
+        # "msoa" is the correct option here, "msoa_code" is supported for
+        # backwards compatibility
+        elif returning in ("msoa", "msoa_code"):
             column = "MSOACode"
         elif returning == "nuts1_region_name":
             column = "Region"
@@ -1208,6 +1210,8 @@ class TPPBackend:
         elif returning == "rural_urban_classification":
             assert round_to_nearest is None
             column = "RuralUrbanClassificationCode"
+        elif returning == "msoa":
+            column = "MSOACode"
         else:
             raise ValueError(f"Unsupported `returning` value: {returning}")
         date_sql, date_joins = self.get_date_sql("PatientAddress", date)

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -1007,7 +1007,10 @@ def test_patients_registered_practice_as_of():
     study = StudyDefinition(
         population=patients.all(),
         stp=patients.registered_practice_as_of("2020-01-01", returning="stp_code"),
-        msoa=patients.registered_practice_as_of("2020-01-01", returning="msoa_code"),
+        msoa=patients.registered_practice_as_of("2020-01-01", returning="msoa"),
+        deprecated_msoa=patients.registered_practice_as_of(
+            "2020-01-01", returning="msoa_code"
+        ),
         region=patients.registered_practice_as_of(
             "2020-01-01", returning="nuts1_region_name"
         ),
@@ -1015,11 +1018,14 @@ def test_patients_registered_practice_as_of():
             "2020-01-01", returning="pseudo_id"
         ),
     )
-    results = study.to_dicts()
-    assert [i["stp"] for i in results] == ["789", "123", ""]
-    assert [i["msoa"] for i in results] == ["E0203", "E0201", ""]
-    assert [i["region"] for i in results] == ["London", "East of England", ""]
-    assert [i["pseudo_id"] for i in results] == ["3", "1", "0"]
+    assert_results(
+        study.to_dicts(),
+        stp=["789", "123", ""],
+        msoa=["E0203", "E0201", ""],
+        deprecated_msoa=["E0203", "E0201", ""],
+        region=["London", "East of England", ""],
+        pseudo_id=["3", "1", "0"],
+    )
 
 
 def test_patients_address_as_of():
@@ -1035,24 +1041,28 @@ def test_patients_address_as_of():
                         EndDate="2018-01-01",
                         ImdRankRounded=100,
                         RuralUrbanClassificationCode=1,
+                        MSOACode="S02001286",
                     ),
                     PatientAddress(
                         StartDate="2018-01-01",
                         EndDate="2020-02-01",
                         ImdRankRounded=200,
                         RuralUrbanClassificationCode=1,
+                        MSOACode="S02001286",
                     ),
                     PatientAddress(
                         StartDate="2019-01-01",
                         EndDate="2022-01-01",
                         ImdRankRounded=300,
                         RuralUrbanClassificationCode=2,
+                        MSOACode="E02001286",
                     ),
                     PatientAddress(
                         StartDate="2022-01-01",
                         EndDate="9999-12-31",
                         ImdRankRounded=500,
                         RuralUrbanClassificationCode=3,
+                        MSOACode="S02001286",
                     ),
                 ]
             ),
@@ -1070,7 +1080,7 @@ def test_patients_address_as_of():
                         EndDate="9999-12-31",
                         ImdRankRounded=600,
                         RuralUrbanClassificationCode=4,
-                        MSOACode="E02002346",
+                        MSOACode="S02001286",
                     ),
                 ]
             ),
@@ -1100,9 +1110,13 @@ def test_patients_address_as_of():
         rural_urban=patients.address_as_of(
             "2020-01-01", returning="rural_urban_classification"
         ),
+        msoa=patients.address_as_of("2020-01-01", returning="msoa"),
     )
     assert_results(
-        study.to_dicts(), imd=["300", "600", "0", "0"], rural_urban=["2", "4", "0", "0"]
+        study.to_dicts(),
+        imd=["300", "600", "0", "0"],
+        rural_urban=["2", "4", "0", "0"],
+        msoa=["E02001286", "S02001286", "", ""],
     )
 
 


### PR DESCRIPTION
As discussed in:
https://github.com/opensafely/cohort-extractor/issues/403#issuecomment-755664777

This also changes the canonical `returning` option in
`registered_practice_as_of` from `msoa_code` to `msoa` for consistency
(though `msoa_code` is still supported for now to avoid breakages).