### PR TITLE
fix: Use correct coding system for APCS procedures

### DIFF
--- a/cohortextractor/patients.py
+++ b/cohortextractor/patients.py
@@ -1687,7 +1687,7 @@ def admitted_to_hospital(
             only year is less disclosive than a date with day, month and year.
         with_these_diagnoses: icd10 codes to match against any diagnosis
         with_these_primary_diagnoses: icd10 codes to match against the primary diagnosis
-        with_these_procedures: OPCS-4 codes to match against the procedure
+        with_these_procedures: opcs4 codes to match against the procedure
         return_expectations: a dictionary defining the incidence and distribution of expected value
             within the population in question.
 

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1834,7 +1834,7 @@ class TPPBackend:
             conditions.append("(" + " OR ".join(fragments) + ")")
 
         if with_these_procedures:
-            assert with_these_procedures.system == "icd10"
+            assert with_these_procedures.system == "opcs4"
             fragments = [
                 f"Der_Procedure_All LIKE {pattern}"
                 for pattern in codelist_to_like_patterns(

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2573,7 +2573,7 @@ def test_patients_admitted_to_hospital():
         with_particular_procedures=patients.admitted_to_hospital(
             on_or_after="2020-02-01",
             returning="number_of_matches_in_period",
-            with_these_procedures=codelist(["YYYC", "YYYD", "YYYE"], "icd10"),
+            with_these_procedures=codelist(["YYYC", "YYYD", "YYYE"], "opcs4"),
         ),
         first_primary_diagnosis=patients.admitted_to_hospital(
             on_or_after="2020-02-01",


### PR DESCRIPTION
This is technically a breaking change, but this argument isn't used by
any existing studies.