### PR TITLE
fix: Use 1 and 0 for boolean columns

### DIFF
--- a/cohortextractor/expectation_generators.py
+++ b/cohortextractor/expectation_generators.py
@@ -132,7 +132,7 @@ def generate(population, **kwargs):
 
     bool_ = kwargs.pop("bool", None)
     if bool_:
-        df["bool"] = True
+        df["bool"] = 1
 
     assert not kwargs, f"Encountered unexpected arguments: {kwargs}"
 
@@ -149,7 +149,7 @@ def generate(population, **kwargs):
 
 def set_empty_values(df, row_selection):
     empty_values = {
-        "bool": False,
+        "bool": 0,
         "int": 0,
         "float": 0.0,
         # Note this is intentionally `None` rather than `""` because at this

--- a/tests/test_expectation_generators.py
+++ b/tests/test_expectation_generators.py
@@ -596,7 +596,7 @@ def test_make_df_from_binary_default_outcome():
     )
     population_size = 10000
     result = study.make_df_from_expectations(population_size)
-    assert len(result[result.died]) == 0.1 * population_size
+    assert len(result[result.died == 1]) == 0.1 * population_size
 
 
 def test_make_df_from_expectations_with_number_of_episodes():


### PR DESCRIPTION
This reflects what we have in the real data. Prior to #395 this issue
was masked by the fact that the presence of Nones in the column caused
Pandas to serialize it using `'1'` and `''`.

Closes #411