### PR TITLE
Make practice registration queries work with dynamic dates

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1184,19 +1184,22 @@ class TPPBackend:
             max_date = "3000-01-01"
         if min_date is None:
             min_date = "1900-01-01"
+        date_condition, date_joins = self.get_date_condition("t", "t.end_date", between)
         return f"""
         SELECT
-          Patient_ID AS patient_id,
-          CASE
-            WHEN
-              MAX(EndDate) BETWEEN {quote(min_date)} AND {quote(max_date)}
-            THEN
-              MAX(EndDate)
-          END AS value
-        FROM
-          RegistrationHistory
-        GROUP BY
-          Patient_ID
+          t.Patient_id,
+          end_date AS value
+        FROM (
+          SELECT
+            Patient_ID AS patient_id,
+            MAX(EndDate) AS end_date
+          FROM
+            RegistrationHistory
+          GROUP BY
+            Patient_ID
+        ) t
+        {date_joins}
+        WHERE {date_condition}
         """
 
     def patients_address_as_of(self, date, returning=None, round_to_nearest=None):

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2942,6 +2942,10 @@ def test_dynamic_index_dates():
         practice_id_at_bar=patients.registered_practice_as_of(
             "earliest_bar", returning="pseudo_id"
         ),
+        deregistration_date=patients.date_deregistered_from_all_supported_practices(
+            on_or_after="latest_foo_before_bar",
+            date_format="YYYY-MM-DD",
+        ),
     )
     assert_results(
         study.to_dicts(),
@@ -2950,6 +2954,7 @@ def test_dynamic_index_dates():
         latest_foo_in_month_after_bar=["2020-04-20"],
         positive_test_after_bar=["2020-05-01"],
         practice_id_at_bar=["2"],
+        deregistration_date=["2020-12-10"],
     )
 
 

--- a/tests/test_tpp_backend.py
+++ b/tests/test_tpp_backend.py
@@ -2893,6 +2893,18 @@ def test_dynamic_index_dates():
                     SGSS_Positive(Earliest_Specimen_Date="2020-01-01"),
                     SGSS_Positive(Earliest_Specimen_Date="2020-05-01"),
                 ],
+                RegistrationHistory=[
+                    RegistrationHistory(
+                        StartDate="1990-01-01",
+                        EndDate="2020-02-01",
+                        Organisation=Organisation(Organisation_ID=1),
+                    ),
+                    RegistrationHistory(
+                        StartDate="2020-02-01",
+                        EndDate="2020-12-10",
+                        Organisation=Organisation(Organisation_ID=2),
+                    ),
+                ],
             ),
         ]
     )
@@ -2927,6 +2939,9 @@ def test_dynamic_index_dates():
             returning="date",
             date_format="YYYY-MM-DD",
         ),
+        practice_id_at_bar=patients.registered_practice_as_of(
+            "earliest_bar", returning="pseudo_id"
+        ),
     )
     assert_results(
         study.to_dicts(),
@@ -2934,6 +2949,7 @@ def test_dynamic_index_dates():
         latest_foo_before_bar=["2020-02-01"],
         latest_foo_in_month_after_bar=["2020-04-20"],
         positive_test_after_bar=["2020-05-01"],
+        practice_id_at_bar=["2"],
     )
 
 


### PR DESCRIPTION
Specifically this means:

    patients.registered_practice_as_of
    patients.date_deregistered_from_all_supported_practices

Closes #413