### PR TITLE
Add logging

### DIFF
--- a/cohortextractor/__init__.py
+++ b/cohortextractor/__init__.py
@@ -6,8 +6,11 @@ from .codelistlib import (
     combine_codelists,
     filter_codes_by_category,
 )
+from .log_utils import init_logging
 from .measure import Measure
 from .study_definition import StudyDefinition
+
+init_logging()
 
 with open(os.path.join(os.path.dirname(__file__), "VERSION")) as version_file:
     __version__ = version_file.read().strip()

--- a/cohortextractor/log_utils.py
+++ b/cohortextractor/log_utils.py
@@ -51,5 +51,12 @@ def init_logging():
                 "handlers": ["console"],
                 "level": os.getenv("LOG_LEVEL", "INFO"),
             },
+            "loggers": {
+                "cohortextractor.sql": {
+                    "handlers": ["console"],
+                    "level": "DEBUG" if os.getenv("LOG_SQL") else "INFO",
+                    "propagate": False,
+                },
+            },
         }
     )

--- a/cohortextractor/log_utils.py
+++ b/cohortextractor/log_utils.py
@@ -1,0 +1,55 @@
+import logging.config
+import os
+
+import structlog
+
+pre_chain = [
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
+]
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    context_class=structlog.threadlocal.wrap_dict(dict),
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+
+def init_logging():
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "formatter": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processor": structlog.dev.ConsoleRenderer(),
+                    "foreign_pre_chain": pre_chain,
+                }
+            },
+            "handlers": {
+                "console": {
+                    "level": "DEBUG",
+                    "class": "logging.StreamHandler",
+                    "formatter": "formatter",
+                }
+            },
+            "root": {
+                "handlers": ["console"],
+                "level": os.getenv("LOG_LEVEL", "INFO"),
+            },
+        }
+    )

--- a/cohortextractor/presto_utils.py
+++ b/cohortextractor/presto_utils.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import readline  # noqa -- importing this adds readline behaviour to input()
 import time
@@ -6,6 +5,7 @@ from urllib.parse import unquote, urlparse
 
 import prestodb
 import requests
+import structlog
 
 # TODO remove this when certificate verification reinstated
 import urllib3
@@ -15,11 +15,7 @@ from tabulate import tabulate
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-
-LOG_SQL = bool(os.getenv("LOG_SQL"))
-
-# this is for @retry()
-logging.basicConfig()
+sql_logger = structlog.get_logger("cohortextractor.sql")
 
 
 def presto_connection_from_url(url):
@@ -178,10 +174,7 @@ class CursorProxy:
         * populates the .description attribute of the cursor
         """
 
-        if LOG_SQL:
-            print("-" * 80)
-            print(sql)
-
+        sql_logger.debug(sql)
         self.cursor.execute(sql, *args, **kwargs)
         self._rows = self.cursor.fetchmany()
 

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ retry
 seaborn
 sqlalchemy
 sqlparse
+structlog
 tabulate
 tinynetrc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,6 +161,8 @@ sqlalchemy==1.3.15
     # via -r requirements.in
 sqlparse==0.3.1
     # via -r requirements.in
+structlog==20.2.0
+    # via -r requirements.in
 tabulate==0.8.7
     # via -r requirements.in
 tinynetrc==1.3.0
@@ -175,6 +177,7 @@ typing-extensions==3.7.4.3
     # via
     #   black
     #   importlib-metadata
+    #   structlog
 urllib3==1.25.9
     # via requests
 virtualenv==20.2.2


### PR DESCRIPTION
This PR:

* allows us to log SQL sent to the presto backend (by setting `LOG_SQL`)
* allows us to get debug logs from underlying libraries (by setting `LOG_LEVEL`)
* changes from `print()` to `logger.info()` for presenting information to users, which means that the output is now slightly noisier -- we may want to revisit this