### PR TITLE
Fix bugs in empty value handling

### DIFF
--- a/cohortextractor/expectation_generators.py
+++ b/cohortextractor/expectation_generators.py
@@ -104,7 +104,8 @@ def generate(population, **kwargs):
         df = df.replace({"category": category_labels})
         df["category"] = df["category"].astype("category")
         # Add empty string as a category to support missing values
-        df["category"].cat.add_categories(new_categories=[""], inplace=True)
+        if "" not in df["category"].cat.categories:
+            df["category"].cat.add_categories(new_categories=[""], inplace=True)
 
     int_ = kwargs.pop("int", None)
     if int_:

--- a/cohortextractor/expressions.py
+++ b/cohortextractor/expressions.py
@@ -169,7 +169,7 @@ def token_for_value(value):
     elif value == "":
         return sqlparse.sql.Token(ttypes.Literal.String.Single, "''")
     else:
-        raise ValueError(f"Invalid empty value: f{value}")
+        raise ValueError(f"Invalid empty value: {value}")
 
 
 def validate_expression(tokens, empty_value_map):

--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -348,7 +348,12 @@ class TPPBackend:
         return ColumnExpression(
             f"CASE {' '.join(clauses)} ELSE {quote(default_value)} END",
             type=column_type,
-            default_value=default_value,
+            # Note, confusingly, this is not the same as the `default_value`
+            # used above. Above it refers to the value the case-expression will
+            # default to in case of no match. Below it refers to the "empty"
+            # value for the column type which is almost always the empty string
+            # apart from bools and ints where it's zero.
+            default_value=self.get_default_value_for_type(column_type),
             source_tables=tables_used,
         )
 


### PR DESCRIPTION
This fixes two bugs in our handling of empty string values.

One is a slightly edge case bug where if you had a `categorised_as` expression whose default value was something other than zero or empty string, and you then attempted to use that column in another `categorised_as` or `satisfying` expression as an implicit boolean it would blow up with an error.

The other is that you'd get an error when attempting to use the empty string as a category in `return_expectations` e.g.

    return_expectations = {
        "rate": "universal",
        "category": {"ratios": {"yes": 0.15, "": 0.85}},
    }

