### PR TITLE
fix: Extract date ranges in reverse order

### DIFF
--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -176,6 +176,7 @@ def _generate_cohort(
     os.makedirs(output_dir, exist_ok=True)
     for index_date in _generate_date_range(index_date_range):
         if index_date is not None:
+            logger.info(f"Setting index_date to {index_date}")
             study.set_index_date(index_date)
             date_suffix = f"_{index_date}"
         else:

--- a/cohortextractor/cohortextractor.py
+++ b/cohortextractor/cohortextractor.py
@@ -207,6 +207,9 @@ def _generate_date_range(date_range_str):
     while start <= end:
         dates.append(start.isoformat())
         start = _increment_date(start, period)
+    # The latest data is generally more interesting/useful so we may as well
+    # extract that first
+    dates.reverse()
     return dates
 
 


### PR DESCRIPTION
In cases where the extraction is taking a very long time we might want
to grab intermediate results out before the job has finished and
generally we want the most recent ones.

Also, log the index_date before running the extract.