### PR TITLE
fix: Fix "decision support values" to work with dynamic dates

### DIFF
--- a/cohortextractor/tpp_backend.py
+++ b/cohortextractor/tpp_backend.py
@@ -1081,15 +1081,16 @@ class TPPBackend:
                     CalculationDateTime AS date
                 FROM (
                     SELECT
-                        Patient_ID,
+                        DecisionSupportValue.Patient_ID AS Patient_ID,
                         {value_column_expression},
                         CalculationDateTime,
                         ROW_NUMBER() OVER (
-                            PARTITION BY Patient_ID
-                            ORDER BY CalculationDateTime {ordering}, Patient_ID
+                            PARTITION BY DecisionSupportValue.Patient_ID
+                            ORDER BY CalculationDateTime {ordering}, DecisionSupportValue.Patient_ID
                         ) AS rownum
                     FROM
                         DecisionSupportValue
+                        {date_joins}
                     WHERE
                         AlgorithmType = {quote(algorithm_type_id)}
                         AND {date_condition}
@@ -1101,17 +1102,18 @@ class TPPBackend:
         else:
             sql = f"""
                 SELECT
-                    Patient_ID AS patient_id,
+                    DecisionSupportValue.Patient_ID AS patient_id,
                     {value_column_expression} AS {value_column_alias},
                     {date_aggregate}(CalculationDateTime) AS date
                 FROM
                     DecisionSupportValue
+                    {date_joins}
                 WHERE
                     AlgorithmType = {quote(algorithm_type_id)}
                     AND {date_condition}
                     AND {missing_values_condition}
                 GROUP BY
-                    Patient_ID
+                    DecisionSupportValue.Patient_ID
             """
         return [sql]
 


### PR DESCRIPTION
This involves including the date join conditions and also fully
qualifying the `patient_id` column which becomes ambiguous once we join
with the extra tables.